### PR TITLE
택배 송장 제조기 [STEP1] gogochang

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		957E1DBC2B5E8D970086FC5F /* ParcelInfomation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E1DBB2B5E8D970086FC5F /* ParcelInfomation.swift */; };
+		957E1DC02B5FEFD30086FC5F /* ParcelInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E1DBF2B5FEFD30086FC5F /* ParcelInfo.swift */; };
+		957E1DC22B5FEFE90086FC5F /* ReceiverInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E1DC12B5FEFE90086FC5F /* ReceiverInfo.swift */; };
+		957E1DC42B5FF0090086FC5F /* ParcelCost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E1DC32B5FF0090086FC5F /* ParcelCost.swift */; };
+		957E1DC62B5FF01F0086FC5F /* Discount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E1DC52B5FF01F0086FC5F /* Discount.swift */; };
+		957E1DC82B5FF0570086FC5F /* DatabaseParcelInformationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E1DC72B5FF0570086FC5F /* DatabaseParcelInformationPersistence.swift */; };
 		C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4F92B46658300A4DDC0 /* AppDelegate.swift */; };
 		C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */; };
 		C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */; };
@@ -21,6 +26,11 @@
 
 /* Begin PBXFileReference section */
 		957E1DBB2B5E8D970086FC5F /* ParcelInfomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInfomation.swift; sourceTree = "<group>"; };
+		957E1DBF2B5FEFD30086FC5F /* ParcelInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInfo.swift; sourceTree = "<group>"; };
+		957E1DC12B5FEFE90086FC5F /* ReceiverInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiverInfo.swift; sourceTree = "<group>"; };
+		957E1DC32B5FF0090086FC5F /* ParcelCost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelCost.swift; sourceTree = "<group>"; };
+		957E1DC52B5FF01F0086FC5F /* Discount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Discount.swift; sourceTree = "<group>"; };
+		957E1DC72B5FF0570086FC5F /* DatabaseParcelInformationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseParcelInformationPersistence.swift; sourceTree = "<group>"; };
 		C741F4F62B46658300A4DDC0 /* ParcelInvoiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParcelInvoiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C741F4F92B46658300A4DDC0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -75,6 +85,11 @@
 				C741F5022B46658400A4DDC0 /* Assets.xcassets */,
 				C741F5042B46658400A4DDC0 /* LaunchScreen.storyboard */,
 				C741F5072B46658400A4DDC0 /* Info.plist */,
+				957E1DC12B5FEFE90086FC5F /* ReceiverInfo.swift */,
+				957E1DBF2B5FEFD30086FC5F /* ParcelInfo.swift */,
+				957E1DC32B5FF0090086FC5F /* ParcelCost.swift */,
+				957E1DC52B5FF01F0086FC5F /* Discount.swift */,
+				957E1DC72B5FF0570086FC5F /* DatabaseParcelInformationPersistence.swift */,
 			);
 			path = ParcelInvoiceMaker;
 			sourceTree = "<group>";
@@ -151,12 +166,17 @@
 			files = (
 				C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */,
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,
+				957E1DC62B5FF01F0086FC5F /* Discount.swift in Sources */,
+				957E1DC82B5FF0570086FC5F /* DatabaseParcelInformationPersistence.swift in Sources */,
 				C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */,
 				C741F50E2B46659500A4DDC0 /* ParcelProcessor.swift in Sources */,
+				957E1DC22B5FEFE90086FC5F /* ReceiverInfo.swift in Sources */,
+				957E1DC02B5FEFD30086FC5F /* ParcelInfo.swift in Sources */,
 				957E1DBC2B5E8D970086FC5F /* ParcelInfomation.swift in Sources */,
 				C741F5102B4675AF00A4DDC0 /* InvoiceViewController.swift in Sources */,
 				C741F5122B468AA300A4DDC0 /* ParcelOrderView.swift in Sources */,
 				C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */,
+				957E1DC42B5FF0090086FC5F /* ParcelCost.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		957E1DBC2B5E8D970086FC5F /* ParcelInfomation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E1DBB2B5E8D970086FC5F /* ParcelInfomation.swift */; };
 		C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4F92B46658300A4DDC0 /* AppDelegate.swift */; };
 		C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */; };
 		C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		957E1DBB2B5E8D970086FC5F /* ParcelInfomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInfomation.swift; sourceTree = "<group>"; };
 		C741F4F62B46658300A4DDC0 /* ParcelInvoiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParcelInvoiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C741F4F92B46658300A4DDC0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +71,7 @@
 				C741F50F2B4675AF00A4DDC0 /* InvoiceViewController.swift */,
 				C741F5132B468AC300A4DDC0 /* InvoiceView.swift */,
 				C741F50D2B46659500A4DDC0 /* ParcelProcessor.swift */,
+				957E1DBB2B5E8D970086FC5F /* ParcelInfomation.swift */,
 				C741F5022B46658400A4DDC0 /* Assets.xcassets */,
 				C741F5042B46658400A4DDC0 /* LaunchScreen.storyboard */,
 				C741F5072B46658400A4DDC0 /* Info.plist */,
@@ -150,6 +153,7 @@
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,
 				C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */,
 				C741F50E2B46659500A4DDC0 /* ParcelProcessor.swift in Sources */,
+				957E1DBC2B5E8D970086FC5F /* ParcelInfomation.swift in Sources */,
 				C741F5102B4675AF00A4DDC0 /* InvoiceViewController.swift in Sources */,
 				C741F5122B468AA300A4DDC0 /* ParcelOrderView.swift in Sources */,
 				C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/DatabaseParcelInformationPersistence.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/DatabaseParcelInformationPersistence.swift
@@ -1,0 +1,19 @@
+//
+//  DatabaseParcelInformationPersistence.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 김창규 on 1/23/24.
+//
+
+import Foundation
+
+class DatabaseParcelInformationPersistence: ParcelInformationPersistence {
+    func save(parcelInformation: ParcelInformationProvider) {
+        // 데이터베이스에 주문 정보 저장
+        print("발송 정보를 데이터베이스에 저장했습니다.")
+    }
+}
+
+protocol ParcelInformationPersistence {
+    func save(parcelInformation: ParcelInformationProvider)
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
@@ -1,0 +1,20 @@
+//
+//  Discount.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 김창규 on 1/23/24.
+//
+
+import Foundation
+
+// 할인 타입
+enum Discount: Int {
+    case none = 0, vip, coupon
+}
+
+// 객체 미용 체조, 3원칙 매직넘버 사용x
+// 할인비율
+enum DiscountRate {
+    static let vip = 0.8
+    static let coupon = 0.5
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
@@ -7,9 +7,10 @@
 import UIKit
 
 class InvoiceView: UIView {
-    let parcelInformation: ParcelInformation
+    // SOLID DIP 적용 추상화된 프로토콜을 가지도록 수정
+    let parcelInformation: ParcelInformationProvider
     
-    init(parcelInformation: ParcelInformation) {
+    init(parcelInformation: ParcelInformationProvider) {
         self.parcelInformation = parcelInformation
         super.init(frame: .zero)
         backgroundColor = .systemBrown
@@ -24,22 +25,26 @@ class InvoiceView: UIView {
         let nameLabel: UILabel = UILabel()
         nameLabel.textColor = .black
         nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        nameLabel.text = "이름 : \(parcelInformation.receiverName)"
+        // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+        nameLabel.text = "이름 : \(parcelInformation.getReceiverName())"
         
         let mobileLabel: UILabel = UILabel()
         mobileLabel.textColor = .black
         mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        mobileLabel.text = "전화 : \(parcelInformation.receiverMobile)"
+        // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+        mobileLabel.text = "전화 : \(parcelInformation.getReceiverMobile())"
         
         let addressLabel: UILabel = UILabel()
         addressLabel.textColor = .black
         addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        addressLabel.text = "주소 : \(parcelInformation.address)"
+        // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+        addressLabel.text = "주소 : \(parcelInformation.getAdress())"
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black
         costLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        costLabel.text = "요금 : \(parcelInformation.discountedCost)"
+        // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+        costLabel.text = "요금 : \(parcelInformation.getDiscountedCost())"
                 
         let mainStackView: UIStackView = .init(arrangedSubviews: [nameLabel, mobileLabel, addressLabel, costLabel])
         mainStackView.axis = .vertical

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
@@ -38,7 +38,7 @@ class InvoiceView: UIView {
         addressLabel.textColor = .black
         addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
         // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
-        addressLabel.text = "주소 : \(parcelInformation.getAdress())"
+        addressLabel.text = "주소 : \(parcelInformation.getAddress())"
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceViewController.swift
@@ -8,9 +8,9 @@ import UIKit
 
 class InvoiceViewController: UIViewController {
 
-    private let parcelInformation: ParcelInformation
+    private let parcelInformation: ParcelInformationProvider
     
-    init(parcelInformation: ParcelInformation) {
+    init(parcelInformation: ParcelInformationProvider) {
         self.parcelInformation = parcelInformation
         super.init(nibName: nil, bundle: nil)
         navigationItem.title = "송장정보"

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelCost.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelCost.swift
@@ -1,0 +1,33 @@
+//
+//  ParcelCost.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 김창규 on 1/23/24.
+//
+
+import Foundation
+
+// 소포 비용
+struct ParcelCost {
+    let deliveryCost: Double
+    private let discount: Discount
+    var discountedCost: Int {
+        switch discount {
+        case .none:
+            return Int(deliveryCost)
+        case .vip:
+            return Int(deliveryCost * DiscountRate.vip)
+        case .coupon:
+            return Int(deliveryCost * DiscountRate.coupon)
+        }
+    }
+    
+    init(deliveryCost: Double, discount: Discount) {
+        self.deliveryCost = deliveryCost
+        self.discount = discount
+    }
+    
+    func getDiscountedCost() -> Int{
+        return discountedCost
+    }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInfo.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInfo.swift
@@ -1,0 +1,32 @@
+//
+//  ParcelInfo.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 김창규 on 1/23/24.
+//
+
+import Foundation
+
+struct ParcelInfo {
+    let address: String
+    let receiver: ReceiverInfo
+    let cost: ParcelCost
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 받는사람 이름을 반환합니다.
+    func getReceiverName() -> String {
+        receiver.getReceiverName()
+    }
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 받는사람 휴대폰을 반환합니다.
+    func getReceiverMobile() -> String {
+        receiver.getReceiverMobile()
+    }
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 할인비용을 반환합니다.
+    func getDiscountedCost() -> Int {
+        return cost.getDiscountedCost()
+    }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInfomation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInfomation.swift
@@ -1,0 +1,110 @@
+//
+//  ParcelInfomation.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 김창규 on 1/22/24.
+//
+
+import Foundation
+
+protocol ParcelInformationProvider {
+    func getAdress() -> String
+    func getReceiverName() -> String
+    func getReceiverMobile() -> String
+    func getDiscountedCost() -> Int
+}
+
+class ParcelInformation: ParcelInformationProvider {
+    private let parcelInfo: ParcelInfo
+
+    init(parcelInfo: ParcelInfo) {
+        self.parcelInfo = parcelInfo
+    }
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 주소를 반환합니다.
+    func getAdress() -> String {
+        return parcelInfo.address
+    }
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 받는사람 이름을 반환합니다.
+    func getReceiverName() -> String {
+        return parcelInfo.getReceiverName()
+    }
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 받는사람 휴대폰번호를 반환합니다.
+    func getReceiverMobile() -> String {
+        return parcelInfo.getReceiverMobile()
+    }
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 할인비용을 반환합니다.
+    func getDiscountedCost() -> Int {
+        return parcelInfo.cost.discountedCost
+    }
+}
+
+struct ParcelInfo {
+    let address: String
+    let receiver: ReceiverInfo
+    let cost: ParcelCost
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 받는사람 이름을 반환합니다.
+    func getReceiverName() -> String {
+        receiver.receiverName
+    }
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 받는사람 휴대폰을 반환합니다.
+    func getReceiverMobile() -> String {
+        receiver.receiverMobile
+    }
+    
+    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
+    // 할인비용을 반환합니다.
+    func getDiscountedCost() -> Int {
+        return cost.discountedCost
+    }
+}
+
+// 보내는사람 정보
+struct ReceiverInfo {
+    let receiverName: String
+    let receiverMobile: String
+}
+
+// 소포 비용
+struct ParcelCost {
+    let deliveryCost: Double
+    private let discount: Discount
+    var discountedCost: Int {
+        switch discount {
+        case .none:
+            return Int(deliveryCost)
+        case .vip:
+            return Int(deliveryCost * DiscountRate.vip)
+        case .coupon:
+            return Int(deliveryCost * DiscountRate.coupon)
+        }
+    }
+    
+    init(deliveryCost: Double, discount: Discount) {
+        self.deliveryCost = deliveryCost
+        self.discount = discount
+    }
+}
+
+// 객체 미용 체조, 3원칙 매직넘버 사용x
+// 할인비율
+enum DiscountRate {
+    static let vip = 0.8
+    static let coupon = 0.5
+}
+
+// 할인 타입
+enum Discount: Int {
+    case none = 0, vip, coupon
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInfomation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInfomation.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 protocol ParcelInformationProvider {
-    func getAdress() -> String
+    func getAddress() -> String
     func getReceiverName() -> String
     func getReceiverMobile() -> String
     func getDiscountedCost() -> Int
 }
 
-class ParcelInformation: ParcelInformationProvider {
+struct ParcelInformation: ParcelInformationProvider {
     private let parcelInfo: ParcelInfo
 
     init(parcelInfo: ParcelInfo) {
@@ -23,7 +23,7 @@ class ParcelInformation: ParcelInformationProvider {
     
     // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
     // 주소를 반환합니다.
-    func getAdress() -> String {
+    func getAddress() -> String {
         return parcelInfo.address
     }
     
@@ -42,69 +42,7 @@ class ParcelInformation: ParcelInformationProvider {
     // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
     // 할인비용을 반환합니다.
     func getDiscountedCost() -> Int {
-        return parcelInfo.cost.discountedCost
+        return parcelInfo.getDiscountedCost()
     }
 }
 
-struct ParcelInfo {
-    let address: String
-    let receiver: ReceiverInfo
-    let cost: ParcelCost
-    
-    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
-    // 받는사람 이름을 반환합니다.
-    func getReceiverName() -> String {
-        receiver.receiverName
-    }
-    
-    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
-    // 받는사람 휴대폰을 반환합니다.
-    func getReceiverMobile() -> String {
-        receiver.receiverMobile
-    }
-    
-    // 객체 미용 체조, 4원칙 한 줄에 한 점만 사용
-    // 할인비용을 반환합니다.
-    func getDiscountedCost() -> Int {
-        return cost.discountedCost
-    }
-}
-
-// 보내는사람 정보
-struct ReceiverInfo {
-    let receiverName: String
-    let receiverMobile: String
-}
-
-// 소포 비용
-struct ParcelCost {
-    let deliveryCost: Double
-    private let discount: Discount
-    var discountedCost: Int {
-        switch discount {
-        case .none:
-            return Int(deliveryCost)
-        case .vip:
-            return Int(deliveryCost * DiscountRate.vip)
-        case .coupon:
-            return Int(deliveryCost * DiscountRate.coupon)
-        }
-    }
-    
-    init(deliveryCost: Double, discount: Discount) {
-        self.deliveryCost = deliveryCost
-        self.discount = discount
-    }
-}
-
-// 객체 미용 체조, 3원칙 매직넘버 사용x
-// 할인비율
-enum DiscountRate {
-    static let vip = 0.8
-    static let coupon = 0.5
-}
-
-// 할인 타입
-enum Discount: Int {
-    case none = 0, vip, coupon
-}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -77,12 +77,16 @@ class ParcelOrderView: UIView {
         }
         
         // 객체미용체조 7원칙 '2개 이상의 원시타입 프로퍼티를 갖는 타입 금지'를 적용하면서 변경
-        let parcelInformation: ParcelInformationProvider = 
-        ParcelInformation(parcelInfo: ParcelInfo(address: address,
-                                                 receiver: ReceiverInfo(receiverName: name,
-                                                                        receiverMobile: mobile),
-                                                 cost: ParcelCost(deliveryCost: cost,
-                                                                  discount: discount)))
+        let parcelInformation: ParcelInformationProvider = ParcelInformation(
+            parcelInfo: ParcelInfo(
+                address: address,
+                receiver: ReceiverInfo(
+                    receiverName: name,
+                    receiverMobile: mobile),
+                cost: ParcelCost(
+                    deliveryCost: cost,
+                    discount: discount)))
+        
         delegate.parcelOrderMade(parcelInformation)
     }
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 protocol ParcelOrderViewDelegate {
-    func parcelOrderMade(_ parcelInformation: ParcelInformation)
+    func parcelOrderMade(_ parcelInformation: ParcelInformationProvider)
 }
 
 class ParcelOrderView: UIView {
@@ -70,17 +70,19 @@ class ParcelOrderView: UIView {
               mobile.isEmpty == false,
               address.isEmpty == false,
               costString.isEmpty == false,
-              let cost: Int = Int(costString),
+              let cost: Double = Double(costString),
               let discount: Discount = Discount(rawValue: discountSegmented.selectedSegmentIndex)
         else {
             return
         }
         
-        let parcelInformation: ParcelInformation = .init(address: address,
-                                                         receiverName: name,
-                                                         receiverMobile: mobile,
-                                                         deliveryCost: cost,
-                                                         discount: discount)
+        // 객체미용체조 7원칙 '2개 이상의 원시타입 프로퍼티를 갖는 타입 금지'를 적용하면서 변경
+        let parcelInformation: ParcelInformationProvider = 
+        ParcelInformation(parcelInfo: ParcelInfo(address: address,
+                                                 receiver: ReceiverInfo(receiverName: name,
+                                                                        receiverMobile: mobile),
+                                                 cost: ParcelCost(deliveryCost: cost,
+                                                                  discount: discount)))
         delegate.parcelOrderMade(parcelInformation)
     }
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
-    private let parcelProcessor: ParcelOrderProcessor = ParcelOrderProcessor()
+    private let parcelProcessor: ParcelOrderProcessor = ParcelOrderProcessor(databaseParcelInformationPersistence: DatabaseParcelInformationPersistence())
     
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -18,7 +18,7 @@ class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func parcelOrderMade(_ parcelInformation: ParcelInformation) {
+    func parcelOrderMade(_ parcelInformation: ParcelInformationProvider) {
         parcelProcessor.process(parcelInformation: parcelInformation) { (parcelInformation) in
             let invoiceViewController: InvoiceViewController = .init(parcelInformation: parcelInformation)
             navigationController?.pushViewController(invoiceViewController, animated: true)

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -8,7 +8,7 @@ import Foundation
 
 class ParcelOrderProcessor {
     // SOLID DIP 적용 추상화된 프로토콜을 가지도록 수정
-    let databaseParcelInformationPersistence: ParcelInformationPersistence
+    private let databaseParcelInformationPersistence: ParcelInformationPersistence
     
     init(databaseParcelInformationPersistence: ParcelInformationPersistence) {
         // 인스턴스를 생성해 주입
@@ -25,13 +25,3 @@ class ParcelOrderProcessor {
     }
 }
 
-class DatabaseParcelInformationPersistence: ParcelInformationPersistence {
-    func save(parcelInformation: ParcelInformationProvider) {
-        // 데이터베이스에 주문 정보 저장
-        print("발송 정보를 데이터베이스에 저장했습니다.")
-    }
-}
-
-protocol ParcelInformationPersistence {
-    func save(parcelInformation: ParcelInformationProvider)
-}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -6,49 +6,32 @@
 
 import Foundation
 
-class ParcelInformation {
-    let address: String
-    var receiverName: String
-    var receiverMobile: String
-    let deliveryCost: Int
-    private let discount: Discount
-    var discountedCost: Int {
-        switch discount {
-        case .none:
-            return deliveryCost
-        case .vip:
-            return deliveryCost / 5 * 4
-        case .coupon:
-            return deliveryCost / 2
-        }
-    }
-
-    init(address: String, receiverName: String, receiverMobile: String, deliveryCost: Int, discount: Discount) {
-        self.address = address
-        self.receiverName = receiverName
-        self.receiverMobile = receiverMobile
-        self.deliveryCost = deliveryCost
-        self.discount = discount
-    }
-}
-
-enum Discount: Int {
-    case none = 0, vip, coupon
-}
-
 class ParcelOrderProcessor {
+    // SOLID DIP 적용 추상화된 프로토콜을 가지도록 수정
+    let databaseParcelInformationPersistence: ParcelInformationPersistence
+    
+    init(databaseParcelInformationPersistence: ParcelInformationPersistence) {
+        // 인스턴스를 생성해 주입
+        self.databaseParcelInformationPersistence = databaseParcelInformationPersistence
+    }
     
     // 택배 주문 처리 로직
-    func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void) {
+    func process(parcelInformation: ParcelInformationProvider, onComplete: (ParcelInformationProvider) -> Void) {
         
         // 데이터베이스에 주문 저장
-        save(parcelInformation: parcelInformation)
+        databaseParcelInformationPersistence.save(parcelInformation: parcelInformation)
         
         onComplete(parcelInformation)
     }
-    
-    func save(parcelInformation: ParcelInformation) {
+}
+
+class DatabaseParcelInformationPersistence: ParcelInformationPersistence {
+    func save(parcelInformation: ParcelInformationProvider) {
         // 데이터베이스에 주문 정보 저장
         print("발송 정보를 데이터베이스에 저장했습니다.")
     }
+}
+
+protocol ParcelInformationPersistence {
+    func save(parcelInformation: ParcelInformationProvider)
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ReceiverInfo.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ReceiverInfo.swift
@@ -1,0 +1,23 @@
+//
+//  ReceiverInfo.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 김창규 on 1/23/24.
+//
+
+import Foundation
+
+// 보내는사람 정보
+struct ReceiverInfo {
+    let receiverName: String
+    let receiverMobile: String
+    
+    func getReceiverName() -> String {
+        return receiverName
+    }
+    
+    func getReceiverMobile() -> String {
+        return receiverMobile
+    }
+}
+


### PR DESCRIPTION
@GREENOVER 
안녕하세요. gogochang입니다.
택배 송장 제조기 [STEP1] 미션 요구사항 PR입니다.
STEP1을 진행하며 고민과 과정을 작성했습니다.
잘못 이해한 부분이나 더 좋은 방법에 대해 조언과 방향을 지시해주시면 감사하겠습니다.

## 고민했던 점
### 객체미용체조 7원칙 ‘2개 이상의 원시타입 프로퍼티를 갖는 타입 금지

#### 새로운 타입으로 분리
- **ParcelInfomation** 타입은 여러가지 원시타입 프로퍼티를 가지고 있었습니다.
주소, 보내는사람이름, 보내는사람 정보, 비용, 할인, Discount 타입에 따른 할인된비용 에서
보내는사람의 이름과 정보 프로퍼티를 **ReciverInfo** 타입으로,
비용,할인 과 같은 금액과 관련된 프로퍼티를   **ParcelCost** 타입으로 새로 생성해 주었습니다.
주소, ReciverInfo, ParcelCost를 다시 하나로 묶어 **ParcelInfo**라는 새로운 타입을 생성하여 분리하였습니다.

#### 매직넘버
- **Discount** 열거형의 케이스에 따라 할인율이 달랐습니다. 이 할인율을 계산하는 코드가 "5x4", "2"라는 매직넘버를 사용하고 있었습니다.
**객체미용 3원칙 원시값과 문자열의 포장**을 적용하기 위해 **DiscountRate** 열거형 생성하여 0.8, 0.5로 Double 타입프로퍼티로 정의해 주고
**discountedCost** 계산을 곱셈으로 변경하여 안전성과 가독성을 개선했습니다.

#### 4원칙 한 줄에 한 점만 사용
- 위 수정사항을 적용 후 **InvoidView** 타입에서 **ParcelInfomation**의 정보를 가져오는 부분에서 여러 점을 사용하게 되어 결합도가 증가하는 문제가 생겼습니다. 
위 원시타입을 분리하는 과정에서 만든 **ParcelInfo** 에서 프로퍼티값을 반환하는 메서드를 생성했습니다.
그리고 이 ParceInfo를 가지는 ParceInfomation에서 ParceInfo의 메서드를 사용하여
각 데이터를 반환하는 메서드를 추가하여 현재 타입이 가지고있는 인스턴스를 통해서만 가져올 수 있도록 수정하여
여러 점을 사용하는 부분을 해결했습니다.

### SOLID SRP 적용
#### 책임 분리
- **ParcelOrderProcessor** 타입의 이름에서도 알 수 있듯이 소포 주문을 처리하는 기능을 담당하고 있습니다. SRP는 단일 책임 원칙(Single Responsibility Principle)을 따르기 위해서는 소포 주문과 관련없은 데이터 베이스 저장기능은 다른 타입으로 구분하여 하나의 책임만 가지도록 수정해야 합니다.
요구사항에 따라 **DatabaseParcelInformationPersistence** 타입을 생성하고 데이터 베이저장 메서드를 옮긴 후 ParcelOrderProcessor 타입의 내부에 프로퍼티로 만들어 저장을 요청하도록 수정했습니다.

#### 어떻게 적용할까?
- 앞으로 코드를 작성하며 타입을 생성할 때 강의에 나와있는 주요 체크포인트를 참고하고 "과연 이 타입이 하나의 책임을 가지고 있는가?"를 끊임 없이 확인해야겠습니다. 한 가지 책임만 가질 수 있도록 하여 가독성, 유지보수에 좋은 코드를 작성할 수 있도록 신경써야겠습니다.

### SOLID DIP 적용
#### 추상화프로토콜에 의존하도록 수정
- SOLID SRP까지 적용하고 나면,  **ParcelOrderProcessor**(상위 계층 모듈)이 **DatabaseParcelInformationPersistence**(하위 계층 모듈)의 세부사항에 의존하고 있는 문제가 발생하여 DIP(Dependency Inversion Principle)원칙에 위배됩니다. 
또 databaseParcelInformationPersistence를 변경하려면 내부 코드를 다시 수정하고 OCP(Open Closed Principle)에도 위배되는 문제가 발생합니다. 이러한 문제를 해결하기 위해 프로토콜을 사용한 추상화한 **ParcelInformationPersistence** 프로토콜을 사용하여 하위 계층 모듈의 세부사항이 아닌 추상화를 소유하도록 했습니다.

#### 어떻게 적용할까?
- 추상화된 프로토콜을 사용하여 기존 코드는 수정하지 않고 타입 내부의 구체 타입 변경이 용이하며,
서로의 의존성을 낮추고 보다 유연한 코드를 작성할 수 있다고 생각했습니다. 타입의 재사용성을 고민하고 공통부분이 무엇인지 생각하여 추상화할 수 있는 연습을 해야겠습니다.

### 파일 생성
- **ParcelProcessor**는 소포를 처리하는 이름을 가지고 있어 **ParcelInfomation**라는 이름의 Swift파일을 따로 생성했습니다.
- 소포를 처리하기 위한 데이터를 정리했습니다.

---

## 해결이 되지 않은 점
### 파일 분리
- 하나의 Swift파일 내부에 서로 다른 클래스,구조체,열거형이 같이 있는것을 정리하고 싶었습니다.
서로 관계가 있다고 생각하여 하나의 Swift파일에 작성했지만 이 기준을 정확히 잡지못했습니다.

---

## 조언을 얻고 싶은 부분
### 4원칙 한 줄에 한 점만 사용
- **InvoiceView**의 **ParcelInfomation의 데이터**를 가져오는 부분에서 건너 건너 접근하며 결합도가 높아진 문제가 있었습니다. 이를 해결하기 위해 Struct가 가지고있는 하위 Struct의 프로퍼티를 가져오기위한 메서드를 추가한 저의 방법이 문제없는지, 더 좋은 방법이 있는지 궁금합니다.

### SOLID DIP 적용
- "실제 구체타입은 추상화를 바라보고있고 상위 계층 모듈은 하위 계층 모듈의 추상화된 프로토콜을 소유하는 것" 그래서 "서로 의존하지 않고 추상화 된 프로토콜을 의존하고 있는 것" 로 이해했습니다. 코드상에서 미션 요구사항을 적용할 때 **ParcelInformation**를 하위 계층 모듈로 둘 때 실제 세부사항에 직접 소유하고 있는 부분은 모두 추상화된 **ParcelInformationProvider** 프로토콜로 수정했습니다. 이 부분에서 제가 이해한것과 적용한것이 맞는지 확인하고 싶습니다.

### 내가 잘못 이해하진 않았는가?
- 제가 고민했던 부분과 잘못이해한 부분이 있어 조언해주시면 감사하겠습니다.

