### PR TITLE
택배송장앱 [STEP 1] Khan1201

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -300,8 +300,8 @@
 				INFOPLIST_FILE = ParcelInvoiceMaker/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -326,8 +326,8 @@
 				INFOPLIST_FILE = ParcelInvoiceMaker/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
@@ -24,22 +24,22 @@ class InvoiceView: UIView {
         let nameLabel: UILabel = UILabel()
         nameLabel.textColor = .black
         nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        nameLabel.text = "이름 : \(parcelInformation.receiverName)"
+        nameLabel.text = "이름 : \(parcelInformation.user.receiver.name)"
         
         let mobileLabel: UILabel = UILabel()
         mobileLabel.textColor = .black
         mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        mobileLabel.text = "전화 : \(parcelInformation.receiverMobile)"
+        mobileLabel.text = "전화 : \(parcelInformation.user.receiver.mobile)"
         
         let addressLabel: UILabel = UILabel()
         addressLabel.textColor = .black
         addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        addressLabel.text = "주소 : \(parcelInformation.address)"
+        addressLabel.text = "주소 : \(parcelInformation.user.address)"
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black
         costLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        costLabel.text = "요금 : \(parcelInformation.discountedCost)"
+        costLabel.text = "요금 : \(parcelInformation.cost.discountedDelivery)"
                 
         let mainStackView: UIStackView = .init(arrangedSubviews: [nameLabel, mobileLabel, addressLabel, costLabel])
         mainStackView.axis = .vertical

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -76,11 +76,19 @@ class ParcelOrderView: UIView {
             return
         }
         
-        let parcelInformation: ParcelInformation = .init(address: address,
-                                                         receiverName: name,
-                                                         receiverMobile: mobile,
-                                                         deliveryCost: cost,
-                                                         discount: discount)
+        let parcelInformation: ParcelInformation = .init(
+            user: .init(
+                address: address,
+                receiver: .init(
+                    name: name,
+                    mobile: mobile
+                )
+            ),
+            cost: .init(
+                delivery: cost,
+                discountCategory: discount
+            )
+        )
         delegate.parcelOrderMade(parcelInformation)
     }
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -7,9 +7,10 @@
 import UIKit
 
 class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
-    private let parcelProcessor: ParcelOrderProcessor = ParcelOrderProcessor()
+    private let parcelProcessor: ParcelOrderPersistence
     
-    init() {
+    init(parcelProcessor: ParcelOrderPersistence = ParcelOrderProcessor()) {
+        self.parcelProcessor = parcelProcessor
         super.init(nibName: nil, bundle: nil)
         navigationItem.title = "택배보내기"
     }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -7,9 +7,9 @@
 import UIKit
 
 class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
-    private let parcelProcessor: ParcelOrderPersistence
+    private let parcelProcessor: ParcelOrderPersistable
     
-    init(parcelProcessor: ParcelOrderPersistence = ParcelOrderProcessor()) {
+    init(parcelProcessor: ParcelOrderPersistable = ParcelOrderProcessor()) {
         self.parcelProcessor = parcelProcessor
         super.init(nibName: nil, bundle: nil)
         navigationItem.title = "택배보내기"

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -36,7 +36,7 @@ import Foundation
 
 // MARK: - 수정 후 코드
 
-class ParcelInformation {
+final class ParcelInformation {
     struct User {
         let address: String
         let receiver: Receiver

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -96,11 +96,11 @@ enum Discount: Int {
 
 // MARK: - 수정 후 코드
 
-class ParcelOrderProcessor: ParcelOrderPersistence {
+class ParcelOrderProcessor: ParcelOrderPersistable {
     
-    let parcelInformationSaver: ParcelInformationPersistence
+    private let parcelInformationSaver: ParcelInformationPersistable
     
-    init(parcelInformationSaver: ParcelInformationPersistence = DatabaseParcelInformationPersistence()) {
+    init(parcelInformationSaver: ParcelInformationPersistable = DatabaseParcelInformationPersistence()) {
         self.parcelInformationSaver = parcelInformationSaver
     }
     
@@ -113,7 +113,7 @@ class ParcelOrderProcessor: ParcelOrderPersistence {
     }
 }
 
-struct DatabaseParcelInformationPersistence: ParcelInformationPersistence {
+struct DatabaseParcelInformationPersistence: ParcelInformationPersistable {
     
     func save(parcelInformation: ParcelInformation) {
         // 데이터베이스에 주문 정보 저장
@@ -121,10 +121,10 @@ struct DatabaseParcelInformationPersistence: ParcelInformationPersistence {
     }
 }
 
-protocol ParcelInformationPersistence {
-    func save(parcelInformation: ParcelInformation) 
+protocol ParcelInformationPersistable {
+    func save(parcelInformation: ParcelInformation)
 }
 
-protocol ParcelOrderPersistence {
+protocol ParcelOrderPersistable {
     func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void)
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -6,29 +6,68 @@
 
 import Foundation
 
+// MARK: - 수정 전 코드
+
+//class ParcelInformation {
+//    let address: String
+//    var receiverName: String
+//    var receiverMobile: String
+//    let deliveryCost: Int
+//    private let discount: Discount
+//    var discountedCost: Int {
+//        switch discount {
+//        case .none:
+//            return deliveryCost
+//        case .vip:
+//            return deliveryCost / 5 * 4
+//        case .coupon:
+//            return deliveryCost / 2
+//        }
+//    }
+//
+//    init(address: String, receiverName: String, receiverMobile: String, deliveryCost: Int, discount: Discount) {
+//        self.address = address
+//        self.receiverName = receiverName
+//        self.receiverMobile = receiverMobile
+//        self.deliveryCost = deliveryCost
+//        self.discount = discount
+//    }
+//}
+
+// MARK: - 수정 후 코드
+
 class ParcelInformation {
-    let address: String
-    var receiverName: String
-    var receiverMobile: String
-    let deliveryCost: Int
-    private let discount: Discount
-    var discountedCost: Int {
-        switch discount {
-        case .none:
-            return deliveryCost
-        case .vip:
-            return deliveryCost / 5 * 4
-        case .coupon:
-            return deliveryCost / 2
-        }
+    struct User {
+        let address: String
+        let receiver: Receiver
     }
 
-    init(address: String, receiverName: String, receiverMobile: String, deliveryCost: Int, discount: Discount) {
-        self.address = address
-        self.receiverName = receiverName
-        self.receiverMobile = receiverMobile
-        self.deliveryCost = deliveryCost
-        self.discount = discount
+    struct Receiver {
+        let name: String
+        let mobile: String
+    }
+    
+    struct Cost {
+        let delivery: Int
+        let discountCategory: Discount
+        var discountedDelivery: Int {
+            switch discountCategory {
+            case .none:
+                return delivery
+            case .vip:
+                return delivery / 5 * 4
+            case .coupon:
+                return delivery / 2
+            }
+        }
+    }
+    
+    let user: User
+    let cost: Cost
+
+    init(user: User, cost: Cost) {
+        self.user = user
+        self.cost = cost
     }
 }
 
@@ -36,19 +75,56 @@ enum Discount: Int {
     case none = 0, vip, coupon
 }
 
-class ParcelOrderProcessor {
+// MARK: - 수정 전 코드
+
+//class ParcelOrderProcessor {
+//    
+//    // 택배 주문 처리 로직
+//    func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void) {
+//        
+//        // 데이터베이스에 주문 저장
+//        save(parcelInformation: parcelInformation)
+//        
+//        onComplete(parcelInformation)
+//    }
+//    
+//    func save(parcelInformation: ParcelInformation) {
+//        // 데이터베이스에 주문 정보 저장
+//        print("발송 정보를 데이터베이스에 저장했습니다.")
+//    }
+//}
+
+// MARK: - 수정 후 코드
+
+class ParcelOrderProcessor: ParcelOrderPersistence {
+    
+    let parcelInformationSaver: ParcelInformationPersistence
+    
+    init(parcelInformationSaver: ParcelInformationPersistence = DatabaseParcelInformationPersistence()) {
+        self.parcelInformationSaver = parcelInformationSaver
+    }
     
     // 택배 주문 처리 로직
     func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void) {
         
         // 데이터베이스에 주문 저장
-        save(parcelInformation: parcelInformation)
-        
+        parcelInformationSaver.save(parcelInformation: parcelInformation)
         onComplete(parcelInformation)
     }
+}
+
+struct DatabaseParcelInformationPersistence: ParcelInformationPersistence {
     
     func save(parcelInformation: ParcelInformation) {
         // 데이터베이스에 주문 정보 저장
         print("발송 정보를 데이터베이스에 저장했습니다.")
     }
+}
+
+protocol ParcelInformationPersistence {
+    func save(parcelInformation: ParcelInformation) 
+}
+
+protocol ParcelOrderPersistence {
+    func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void)
 }


### PR DESCRIPTION
@YebinKim 
안녕하세요 vivi !! 👋👋
개념 복습과 나름의 고민끝에 완성하게 되었습니다 😇
이번 프로젝트를 통해서 새로운 것을 느끼면서도 자신을 반성하게 되었습니다 ..! 😭
요구사항을 충족하고, 진행하면서 고민했던 점들 질문 드릴려고 합니다 🙏

## 고민했던점
### 객체미용체조 7원칙 '2개 이상의 원시타입 프로퍼티를 갖는 타입 금지'
해당 원칙을 보면서 (?) 표정을 지었습니다. class 내부 함수를 리팩터링 하는 원칙들은 바로 납득이 갔었는데, 이 원칙은 이걸 지킬수 있을까..? 라는 생각이 먼저 들었습니다. `ParcelInformation` 내부 프로퍼티를 연관성을 찾아서 분리하도록 노력했고, 분리하는 과정에서 좀 억지로 끼워맞춘 듯한 느낌도 들었습니다. `ParcelInformation`을 크게 `User,` `Cost` 타입으로 나누고,  `User`에는 `address(String)`, `Receiver` 타입으로 나누었습니다. `address`는 자주 변경되지 않을 것이라 생각하여서 분리하였고, `Receiver`은 가족중 대신 받는사람이 생길 수도 있기 때문에 따로 묶었습니다.
`Cost`에는 `delivery(Int)`, `Discount`, `discountedDelivery(Int)` 타입으로 나누었습니다.

### SRP 적용
SOLID 원칙 중 SRP는 Single Responsibility Principle - 단일 책임 원칙 입니다. 모든 클래스는 하나의 책임만 가져야하는 원칙이며, 클래스가 여러개의 책임을 맡고있다면 이를 분리해야 합니다. `ParcelOrderProcessor`에서 주문 처리와 저장을 하는 여러가지 책임을 맡고 있습니다. 
`ParcelOrderProcessor`에서는 이름과 맞게 택배 주문 처리 책임만 맡아야하며, 저장 로직은 다른 클래스에 부여하여야 합니다. `DatabaseParcelInformationPersistence` 클래스를 만들어 저장 책임을 맡도록하고, `ParcelOrderProcessor`에서 `DatabaseParcelInformationPersistence` 프로퍼티를 만들어 저장을 요청하도록 했습니다.

### DIP 적용
SOLID 원칙 중 DIP는 Dependency Inversion Principle - 의존성 역전 원칙 입니다. 상위모듈이 하위모듈을 의존하는 전통적인 의존관계를 역전 시킴으로써, 상위 모듈이 하위 모듈으로부터 독립적이게 될 수 있습니다. 상위 클래스가 하위 클래스를 의존하지 않게되고, 둘 다 추상 타입(protocol)을 의존하게 되어 결합이 느슨해지는 관계가 됩니다. SRP를 적용해서 책임을 분리했지만, `ParcelOrderProcessor`에는 `DatabaseParcelInformationPersistence`의 의존성을 가지고 있습니다. 이는 `DatabaseParcelInformationPersistence` 변경사항이 `ParcelOrderProcessor`에도 영향이 갈 수 있습니다. 의존성을 분리해주기 위해선 protocol을 사용하면 됩니다. `ParcelInformationPersistence` protocol을 생성하여 기능을 정의해준 후, `DatabaseParcelInformationPersistence`에 해당 프로토콜을 채택합니다. 기존의 `ParcelOrderProcessor`의 `DatabaseParcelInformationPersistence` 클래스 타입을 `ParcelInformationPersistence` 프로토콜 타입으로 변경해주고 init() 시점에 `DatabaseParcelInformationPersistence`의 인스턴스를 생성하여 의존성을 주입 해줬습니다.

<br>

## 해결이 되지 않은 점
### 객체미용체조 7원칙 '2개 이상의 원시타입 프로퍼티를 갖는 타입 금지'
- `delivery(Int)`, `discount`, `discountedDelivery(Int)` 프로퍼티를 `Cost` 타입으로 묶었고, `discountedDelivery(Int)`는 computed property입니다. computed property는 init()을 따로 하지 않으므로 객체미용체조 7원칙의 프로퍼티로 구분되지 않는다고 생각하여 3개로 묶었습니다. 여기서 제가 생각한 부분이 맞는지 궁금합니다 !! 
- 할인된 가격 프로퍼티(연산 프로퍼티)는 기존 가격 프로퍼티와 discount 프로퍼티가 있어야 연산을 할 수 있어서 다 같이 묶었습니다. 혹시 이것을 분리 할 수 있는 방법이 있는지 궁금합니다 !

<br>

## 조언을 얻고 싶은 부분
### 객체미용체조 7원칙 '2개 이상의 원시타입 프로퍼티를 갖는 타입 금지'
해당 원칙을 지켰을 때 내부의 프로퍼티를 접근하기 위해서 .(chain)이 많이 일어날 것 같은데 그냥 놔둬도 괜찮을지 아니면 상위타입에 하위 프로퍼티를 바로 접근 할 수 있도록 함수나 연산 프로퍼티를 생성해줄지 의문이였습니다. 후자로 한다면 접근할 프로퍼티가 많다면 다 생성해줘야 하는 점과 프로퍼티 네임이 바뀌면 쉽게 접근하도록 만들어놓은 함수나 프로퍼티도 다시 네이밍을 해야하는 단점이 생길 것 같습니다. 이 부분에서 제 생각은 전자입니다. vivi님의 의견은 어떤지 궁금합니다 !

### SRP 적용, DIP 적용
SRP를 적용하면 DIP도 적용해야 함으로 수많은 class와 protocol 타입들이 생성 될 것 같습니다. 이에따라 관리도 무척 어려울 것이라 생각이 듭니다. 기능(class)별로 파일(.swift)을 따로 만들어 내부에 기능 함수랑 기능을 추상화한 protocol을 만들어 관리하는 방식을 생각해 봤는데, vivi님의 의견은 어떤지 궁금합니다! 관리하는 방식 및 네이밍에서 감이 잘 잡히지 않네요 😂
