### PR TITLE
택배 송장 제조기 [STEP 1] Choiy

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7DCE0C022B6128EB00EAA5CD /* ReceiverInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */; };
+		7DCE0C042B61298A00EAA5CD /* CostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C032B61298A00EAA5CD /* CostInformation.swift */; };
 		C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4F92B46658300A4DDC0 /* AppDelegate.swift */; };
 		C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */; };
 		C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */; };
@@ -19,6 +21,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiverInformation.swift; sourceTree = "<group>"; };
+		7DCE0C032B61298A00EAA5CD /* CostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostInformation.swift; sourceTree = "<group>"; };
 		C741F4F62B46658300A4DDC0 /* ParcelInvoiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParcelInvoiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C741F4F92B46658300A4DDC0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +73,8 @@
 				C741F50F2B4675AF00A4DDC0 /* InvoiceViewController.swift */,
 				C741F5132B468AC300A4DDC0 /* InvoiceView.swift */,
 				C741F50D2B46659500A4DDC0 /* ParcelProcessor.swift */,
+				7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */,
+				7DCE0C032B61298A00EAA5CD /* CostInformation.swift */,
 				C741F5022B46658400A4DDC0 /* Assets.xcassets */,
 				C741F5042B46658400A4DDC0 /* LaunchScreen.storyboard */,
 				C741F5072B46658400A4DDC0 /* Info.plist */,
@@ -146,6 +152,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7DCE0C042B61298A00EAA5CD /* CostInformation.swift in Sources */,
 				C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */,
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,
 				C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */,
@@ -153,6 +160,7 @@
 				C741F5102B4675AF00A4DDC0 /* InvoiceViewController.swift in Sources */,
 				C741F5122B468AA300A4DDC0 /* ParcelOrderView.swift in Sources */,
 				C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */,
+				7DCE0C022B6128EB00EAA5CD /* ReceiverInformation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		7DCE0C022B6128EB00EAA5CD /* ReceiverInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */; };
 		7DCE0C042B61298A00EAA5CD /* CostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C032B61298A00EAA5CD /* CostInformation.swift */; };
+		7DCE0C062B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C052B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift */; };
 		C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4F92B46658300A4DDC0 /* AppDelegate.swift */; };
 		C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */; };
 		C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */; };
@@ -23,6 +24,7 @@
 /* Begin PBXFileReference section */
 		7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiverInformation.swift; sourceTree = "<group>"; };
 		7DCE0C032B61298A00EAA5CD /* CostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostInformation.swift; sourceTree = "<group>"; };
+		7DCE0C052B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseParcelInformationPersistence.swift; sourceTree = "<group>"; };
 		C741F4F62B46658300A4DDC0 /* ParcelInvoiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParcelInvoiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C741F4F92B46658300A4DDC0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -73,6 +75,7 @@
 				C741F50F2B4675AF00A4DDC0 /* InvoiceViewController.swift */,
 				C741F5132B468AC300A4DDC0 /* InvoiceView.swift */,
 				C741F50D2B46659500A4DDC0 /* ParcelProcessor.swift */,
+				7DCE0C052B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift */,
 				7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */,
 				7DCE0C032B61298A00EAA5CD /* CostInformation.swift */,
 				C741F5022B46658400A4DDC0 /* Assets.xcassets */,
@@ -158,6 +161,7 @@
 				C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */,
 				C741F50E2B46659500A4DDC0 /* ParcelProcessor.swift in Sources */,
 				C741F5102B4675AF00A4DDC0 /* InvoiceViewController.swift in Sources */,
+				7DCE0C062B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift in Sources */,
 				C741F5122B468AA300A4DDC0 /* ParcelOrderView.swift in Sources */,
 				C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */,
 				7DCE0C022B6128EB00EAA5CD /* ReceiverInformation.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/CostInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/CostInformation.swift
@@ -1,0 +1,33 @@
+//
+//  Cost.swift
+//  ParcelInvoiceMaker
+//
+//  Created by Daegeon Choi on 2024/01/24.
+//
+
+import Foundation
+
+struct CostInformation {
+    let deliveryCost: Int
+    private let discount: Discount
+    
+    var discountedCost: Int {
+        switch discount {
+        case .none:
+            return deliveryCost
+        case .vip:
+            return deliveryCost / 5 * 4
+        case .coupon:
+            return deliveryCost / 2
+        }
+    }
+    
+    init(deliveryCost: Int, discount: Discount) {
+        self.deliveryCost = deliveryCost
+        self.discount = discount
+    }
+}
+
+enum Discount: Int {
+    case none = 0, vip, coupon
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/DatabaseParcelInformationPersistence.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/DatabaseParcelInformationPersistence.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-class DatabaseParcelInformationPersistence {
+protocol ParcelInformationPersistence {
+    func save(parcelInformation: ParcelInformation)
+}
+
+class DatabaseParcelInformationPersistence: ParcelInformationPersistence {
     
     func save(parcelInformation: ParcelInformation) {
         // 데이터베이스에 주문 정보 저장

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/DatabaseParcelInformationPersistence.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/DatabaseParcelInformationPersistence.swift
@@ -1,0 +1,16 @@
+//
+//  DatabaseParcelInformationPersistence.swift
+//  ParcelInvoiceMaker
+//
+//  Created by Daegeon Choi on 2024/01/24.
+//
+
+import Foundation
+
+class DatabaseParcelInformationPersistence {
+    
+    func save(parcelInformation: ParcelInformation) {
+        // 데이터베이스에 주문 정보 저장
+        print("발송 정보를 데이터베이스에 저장했습니다.")
+    }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
@@ -24,22 +24,22 @@ class InvoiceView: UIView {
         let nameLabel: UILabel = UILabel()
         nameLabel.textColor = .black
         nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        nameLabel.text = "이름 : \(parcelInformation.receiverName)"
+        nameLabel.text = "이름 : \(parcelInformation.reciverInformation.name)"
         
         let mobileLabel: UILabel = UILabel()
         mobileLabel.textColor = .black
         mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        mobileLabel.text = "전화 : \(parcelInformation.receiverMobile)"
+        mobileLabel.text = "전화 : \(parcelInformation.reciverInformation.mobile)"
         
         let addressLabel: UILabel = UILabel()
         addressLabel.textColor = .black
         addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        addressLabel.text = "주소 : \(parcelInformation.address)"
+        addressLabel.text = "주소 : \(parcelInformation.reciverInformation.address)"
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black
         costLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        costLabel.text = "요금 : \(parcelInformation.discountedCost)"
+        costLabel.text = "요금 : \(parcelInformation.costInformation.discountedCost)"
                 
         let mainStackView: UIStackView = .init(arrangedSubviews: [nameLabel, mobileLabel, addressLabel, costLabel])
         mainStackView.axis = .vertical

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -7,9 +7,10 @@
 import UIKit
 
 class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
-    private let parcelProcessor: ParcelOrderProcessor = ParcelOrderProcessor()
+    private let parcelProcessor: ParcelOrderProcessor
     
-    init() {
+    init(parcelProcessor: ParcelOrderProcessor) {
+        self.parcelProcessor = parcelProcessor
         super.init(nibName: nil, bundle: nil)
         navigationItem.title = "택배보내기"
     }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -7,10 +7,10 @@
 import UIKit
 
 class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
-    private let parcelProcessor: ParcelOrderProcessor
+    private let orderProcessor: OrderProcessor
     
-    init(parcelProcessor: ParcelOrderProcessor) {
-        self.parcelProcessor = parcelProcessor
+    init() {
+        self.orderProcessor = ParcelOrderProcessor()
         super.init(nibName: nil, bundle: nil)
         navigationItem.title = "택배보내기"
     }
@@ -20,7 +20,7 @@ class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
     }
     
     func parcelOrderMade(_ parcelInformation: ParcelInformation) {
-        parcelProcessor.process(parcelInformation: parcelInformation) { (parcelInformation) in
+        orderProcessor.process(parcelInformation: parcelInformation) { (parcelInformation) in
             let invoiceViewController: InvoiceViewController = .init(parcelInformation: parcelInformation)
             navigationController?.pushViewController(invoiceViewController, animated: true)
         }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -18,17 +18,15 @@ class ParcelInformation {
 
 class ParcelOrderProcessor {
     
+    private let databasePersistence: DatabaseParcelInformationPersistence = DatabaseParcelInformationPersistence()
+    
     // 택배 주문 처리 로직
     func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void) {
         
         // 데이터베이스에 주문 저장
-        save(parcelInformation: parcelInformation)
+        databasePersistence.save(parcelInformation: parcelInformation)
         
         onComplete(parcelInformation)
     }
     
-    func save(parcelInformation: ParcelInformation) {
-        // 데이터베이스에 주문 정보 저장
-        print("발송 정보를 데이터베이스에 저장했습니다.")
-    }
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -18,7 +18,11 @@ class ParcelInformation {
 
 class ParcelOrderProcessor {
     
-    private let databasePersistence: DatabaseParcelInformationPersistence = DatabaseParcelInformationPersistence()
+    private var databasePersistence: ParcelInformationPersistence
+    
+    init() {
+        self.databasePersistence = DatabaseParcelInformationPersistence()
+    }
     
     // 택배 주문 처리 로직
     func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void) {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -7,33 +7,13 @@
 import Foundation
 
 class ParcelInformation {
-    let address: String
-    var receiverName: String
-    var receiverMobile: String
-    let deliveryCost: Int
-    private let discount: Discount
-    var discountedCost: Int {
-        switch discount {
-        case .none:
-            return deliveryCost
-        case .vip:
-            return deliveryCost / 5 * 4
-        case .coupon:
-            return deliveryCost / 2
-        }
-    }
+    let reciverInformation: ReceiverInformation
+    let costInformation: CostInformation
 
     init(address: String, receiverName: String, receiverMobile: String, deliveryCost: Int, discount: Discount) {
-        self.address = address
-        self.receiverName = receiverName
-        self.receiverMobile = receiverMobile
-        self.deliveryCost = deliveryCost
-        self.discount = discount
+        self.reciverInformation = ReceiverInformation(address: address, name: receiverName, mobile: receiverMobile)
+        self.costInformation = CostInformation(deliveryCost: deliveryCost, discount: discount)
     }
-}
-
-enum Discount: Int {
-    case none = 0, vip, coupon
 }
 
 class ParcelOrderProcessor {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -16,7 +16,11 @@ class ParcelInformation {
     }
 }
 
-class ParcelOrderProcessor {
+protocol OrderProcessor {
+    func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void)
+}
+
+class ParcelOrderProcessor: OrderProcessor {
     
     private var databasePersistence: ParcelInformationPersistence
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ReceiverInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ReceiverInformation.swift
@@ -1,0 +1,20 @@
+//
+//  ReceiverInformation.swift
+//  ParcelInvoiceMaker
+//
+//  Created by Daegeon Choi on 2024/01/24.
+//
+
+import Foundation
+
+struct ReceiverInformation {
+    let address: String
+    let name: String
+    let mobile: String
+    
+    init(address: String, name: String, mobile: String) {
+        self.address = address
+        self.name = name
+        self.mobile = mobile
+    }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/SceneDelegate.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/SceneDelegate.swift
@@ -14,7 +14,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let scene: UIWindowScene = (scene as? UIWindowScene) else { return }
         
-        let viewController: ParcelOrderViewController = ParcelOrderViewController()
+        let parcelProcessor: ParcelOrderProcessor = ParcelOrderProcessor()
+        let viewController: ParcelOrderViewController = ParcelOrderViewController(parcelProcessor: parcelProcessor)
+        
         let navigationController: UINavigationController = UINavigationController(rootViewController: viewController)
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.navigationBar.tintColor = .black

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/SceneDelegate.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/SceneDelegate.swift
@@ -14,9 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let scene: UIWindowScene = (scene as? UIWindowScene) else { return }
         
-        let parcelProcessor: ParcelOrderProcessor = ParcelOrderProcessor()
-        let viewController: ParcelOrderViewController = ParcelOrderViewController(parcelProcessor: parcelProcessor)
-        
+        let viewController: ParcelOrderViewController = ParcelOrderViewController()
         let navigationController: UINavigationController = UINavigationController(rootViewController: viewController)
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.navigationBar.tintColor = .black


### PR DESCRIPTION
@KYHyeon
안녕하세요! 미션 수행이 조금 늦게 마무리 되었네요 ㅠㅠ
미션 진행하면서 궁금했던 점들이 있었는데 질문드리고 싶습니다 🙌

## 고민했던 점
### 객체미용체조 7원칙 ‘2개 이상의 원시타입 프로퍼티를 갖는 타입 금지‘
- `receiverName`과 `receiverMobile`을 `ReceiverInformation`이라는 구조체를 생성하여 묶어주었는데, `address` 도 같이 묶어줄지 말지 고민했습니다
    - `address` 또한 `ReceiverInformation`이라는 구조체에 들어갈 수 있는, 비슷한 분류의 데이터이기 때문에 묶어주었습니다.
    - 하지만 `address`까지 같은 구조체에 담을 경우 한 구조체에 `receiverName`, `receiverMobile`, `address` 3개의 원시타입 프로퍼티를 가지는 타입이 되고, 이를 해결하기 위해 또다른 구조체를 생성할 경우 담고 있는 정보에 비해 구조체가 너무 많은 오버엔지니어링이 되지 않을까 고민하였습니다.
- `discountedCost`라는 계산 프로퍼티가 `discount` 인스턴스에 완전히 의존하고 있기 때문에 이 두 프로퍼티를 같은 구조체로 묶어주었습니다.

### SOLID DIP 적용
- 미션에서 제시된 `ParcelOrderProcessor` 뿐만 아니라 `ParcelOrderViewController`에서도 `ParcelOrderProcessor`라는 구체 타입을 의존해 DIP가 적용되지 않았다고 생각해 `OrderProcessor`라는 프로토콜을 만들어 수정해 주었습니다

---

## 조언을 얻고 싶은 부분
### 객체미용체조 7원칙 ‘2개 이상의 원시타입 프로퍼티를 갖는 타입 금지‘
- `discountedCost` 처럼 다른 프로퍼티에 의존적인 계산 프로퍼티의 경우 새로운 타입으로 묶어줄때 그대로 분리하는 것이 좋은지, 분리하지 않고 분리된 타입의 값에 접근하여 사용하도록 둘지, 또는 계산 프로퍼티의 형식을 버리고 메서드와 같은 다른 방식을 사용하는 방향으로 수정하는 것이 좋을지 궁금합니다.
```swift
// 현재는 이런 방식으로 해결되어 있습니다
struct CostInformation {
    let deliveryCost: Int
    private let discount: Discount
    
    var discountedCost: Int {
        switch discount {
        case .none:
            return deliveryCost
        case .vip:
            return deliveryCost / 5 * 4
        case .coupon:
            return deliveryCost / 2
        }
    }
    
    init(deliveryCost: Int, discount: Discount) {
        self.deliveryCost = deliveryCost
        self.discount = discount
    }
}
```
### 객체미용체조 4원칙 ‘한 줄에 한 점만 사용‘
- 객체 미용체조 2원칙을 위해 `ParcelInformation`의 데이터에 접근하기 위해 구조체를 한번 더 거쳐야 하는 상황이 되었습니다.
```swift
// 2원칙 적용 전
nameLabel.text = "이름 : \(parcelInformation.receiverName)"

// 2원칙 적용 후
nameLabel.text = "이름 : \(parcelInformation.reciverInformation.name)"
```
- 이런 상황에서 `let reciverInformation = parcelInformation.reciverInformation`과 `reciverInformation .name`으로 분리가 가능할 것 같은데, 이런 방식을 사용하면 결합도가 낮아진다고 볼 수 있을까요?

### SOLID DIP 적용
- 의존성 역전을 위해 프로토콜 타입으로 선언된 인스턴스들을 `init()`에서 초기화시 주입해 주는 것이 좋은지, 또는 `init`메서드의 파라미터로 해당 인스턴스를 주입받아 초기화 해주는 것이 의존성 분리에 적합한지 잘 모르겠습니다
   - 처음에는 메서드의 파라미터로 주입받는 방식으로 구현하였다가, 오히려 뷰컨트롤러 설정만 이루어지는 부분에서 로직을 담당하는 클래스나 구조체까지 생성하게 되어 오히려 좋지 않은 방식인가 싶어 `init`에서 해당 인스턴스들을 초기화해 주는 방식으로 수정하였습니다
```swift
// 1. init 메서드의 파라미터로 주입받는 방식
let parcelProcessor: ParcelOrderProcessor = ParcelOrderProcessor()
let viewController: ParcelOrderViewController = ParcelOrderViewController(parcelProcessor: parcelProcessor)

class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
    private let orderProcessor: OrderProcessor
    
    init(parcelProcessor: OrderProcessor) {
        super.init(nibName: nil, bundle: nil)
        navigationItem.title = "택배보내기"
    }
...
}
```
```swift
// 2. init 함수에서 직접 선언해 주입하는 방식
let viewController: ParcelOrderViewController = ParcelOrderViewController()

class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
    private let orderProcessor: OrderProcessor
    
    init() {
        self.orderProcessor = ParcelOrderProcessor()
        super.init(nibName: nil, bundle: nil)
        navigationItem.title = "택배보내기"
    }
...
}
```