### PR TITLE
택배송장 [STEP 1] kodirbek

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		81AFFC192B613A59002C62DC /* ParcelInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81AFFC182B613A59002C62DC /* ParcelInformation.swift */; };
 		C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4F92B46658300A4DDC0 /* AppDelegate.swift */; };
 		C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */; };
 		C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		81AFFC182B613A59002C62DC /* ParcelInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformation.swift; sourceTree = "<group>"; };
 		C741F4F62B46658300A4DDC0 /* ParcelInvoiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParcelInvoiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C741F4F92B46658300A4DDC0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -64,11 +66,12 @@
 			children = (
 				C741F4F92B46658300A4DDC0 /* AppDelegate.swift */,
 				C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */,
+				81AFFC182B613A59002C62DC /* ParcelInformation.swift */,
+				C741F50D2B46659500A4DDC0 /* ParcelProcessor.swift */,
 				C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */,
 				C741F5112B468AA300A4DDC0 /* ParcelOrderView.swift */,
 				C741F50F2B4675AF00A4DDC0 /* InvoiceViewController.swift */,
 				C741F5132B468AC300A4DDC0 /* InvoiceView.swift */,
-				C741F50D2B46659500A4DDC0 /* ParcelProcessor.swift */,
 				C741F5022B46658400A4DDC0 /* Assets.xcassets */,
 				C741F5042B46658400A4DDC0 /* LaunchScreen.storyboard */,
 				C741F5072B46658400A4DDC0 /* Info.plist */,
@@ -146,6 +149,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				81AFFC192B613A59002C62DC /* ParcelInformation.swift in Sources */,
 				C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */,
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,
 				C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
@@ -24,22 +24,22 @@ class InvoiceView: UIView {
         let nameLabel: UILabel = UILabel()
         nameLabel.textColor = .black
         nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        nameLabel.text = "이름 : \(parcelInformation.receiverName)"
+        nameLabel.text = "이름 : \(parcelInformation.getReceiverName())"
         
         let mobileLabel: UILabel = UILabel()
         mobileLabel.textColor = .black
         mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        mobileLabel.text = "전화 : \(parcelInformation.receiverMobile)"
+        mobileLabel.text = "전화 : \(parcelInformation.getReceiverMobile())"
         
         let addressLabel: UILabel = UILabel()
         addressLabel.textColor = .black
         addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        addressLabel.text = "주소 : \(parcelInformation.address)"
+        addressLabel.text = "주소 : \(parcelInformation.getReceiverAddress())"
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black
         costLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        costLabel.text = "요금 : \(parcelInformation.discountedCost)"
+        costLabel.text = "요금 : \(parcelInformation.getDiscountedCost())"
                 
         let mainStackView: UIStackView = .init(arrangedSubviews: [nameLabel, mobileLabel, addressLabel, costLabel])
         mainStackView.axis = .vertical

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
@@ -1,0 +1,90 @@
+//
+//  ParcelInformation.swift
+//  ParcelInvoiceMaker
+//
+//  Created by kodirbek on 1/24/24.
+//
+
+import Foundation
+
+enum Discount: Int {
+    case none = 0, vip, coupon
+}
+
+struct ReceiverInfo {
+    let address: String
+    let receiverName: String
+    let receiverMobile: String
+}
+
+struct DeliveryCost {
+    private var cost: Int
+    
+    private static func validate(_ cost: Int) throws {
+        guard cost > 0 else {
+            throw NSError() as Error
+        }
+    }
+    
+    init(_ cost: Int) throws {
+        try Self.validate(cost)
+        self.cost = cost
+    }
+    
+    func getCost() -> Int {
+        cost
+    }
+}
+
+struct DiscountedCost {
+    static let fiftyPerDiscount: Double = 0.5
+    static let twentyPerDiscount: Double = 0.8
+    
+    static func getDiscountedCost(deliveryCost: DeliveryCost, discount: Discount) -> Int {
+        switch discount {
+            case .none:
+                return deliveryCost.getCost()
+            case .vip:
+                return Int(Double(deliveryCost.getCost()) * twentyPerDiscount)
+            case .coupon:
+                return Int(Double(deliveryCost.getCost()) * fiftyPerDiscount)
+        }
+    }
+}
+
+
+class ParcelInformation {
+    private let receiverInfo: ReceiverInfo
+    private let deliveryCost: DeliveryCost
+    private let discount: Discount
+    
+    private var discountedCost: Int {
+        DiscountedCost.getDiscountedCost(deliveryCost: deliveryCost, discount: discount)
+    }
+    
+    init(receiverInfo: ReceiverInfo, deliveryCost: DeliveryCost, discount: Discount) {
+        self.receiverInfo = receiverInfo
+        self.deliveryCost = deliveryCost
+        self.discount = discount
+    }
+    
+    // InvoiceView 안에선 '4원칙: 한 줄에 한 점만 사용'을 지키기 위해서 함수 추가
+    func getReceiverName() -> String {
+        receiverInfo.receiverName
+    }
+    
+    func getReceiverAddress() -> String {
+        receiverInfo.address
+    }
+    
+    func getReceiverMobile() -> String {
+        receiverInfo.receiverMobile
+    }
+    
+    func getDiscountedCost() -> Int {
+        discountedCost
+    }
+    
+}
+
+

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -71,15 +71,15 @@ class ParcelOrderView: UIView {
               address.isEmpty == false,
               costString.isEmpty == false,
               let cost: Int = Int(costString),
+              let deliveryCost: DeliveryCost = try? .init(cost),
               let discount: Discount = Discount(rawValue: discountSegmented.selectedSegmentIndex)
         else {
             return
         }
-        
-        let parcelInformation: ParcelInformation = .init(address: address,
-                                                         receiverName: name,
-                                                         receiverMobile: mobile,
-                                                         deliveryCost: cost,
+        let parcelInformation: ParcelInformation = .init(receiverInfo: ReceiverInfo(address: address, 
+                                                                                    receiverName: name,
+                                                                                    receiverMobile: mobile),
+                                                         deliveryCost: deliveryCost,
                                                          discount: discount)
         delegate.parcelOrderMade(parcelInformation)
     }
@@ -161,4 +161,5 @@ class ParcelOrderView: UIView {
             mainStackView.bottomAnchor.constraint(lessThanOrEqualTo: safeArea.bottomAnchor, constant: -16)
         ])
     }
+    
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -7,6 +7,7 @@
 import UIKit
 
 class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
+    
     private let parcelProcessor: ParcelOrderProcessor = ParcelOrderProcessor()
     
     init() {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -8,9 +8,11 @@ import UIKit
 
 class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
     
-    private let parcelProcessor: ParcelOrderProcessor = ParcelOrderProcessor()
+    // 원래 갖고 있는 ParcelOrderProcessor 타입 의존성을 없애기 위해서 추상화 주입
+    private let parcelProcessor: ParcelOrderProcessorProtocol
     
-    init() {
+    init(parcelProcessor: ParcelOrderProcessorProtocol) {
+        self.parcelProcessor = parcelProcessor
         super.init(nibName: nil, bundle: nil)
         navigationItem.title = "택배보내기"
     }
@@ -19,15 +21,15 @@ class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func loadView() {
+        view = ParcelOrderView(delegate: self)
+    }
+    
     func parcelOrderMade(_ parcelInformation: ParcelInformation) {
         parcelProcessor.process(parcelInformation: parcelInformation) { (parcelInformation) in
             let invoiceViewController: InvoiceViewController = .init(parcelInformation: parcelInformation)
             navigationController?.pushViewController(invoiceViewController, animated: true)
         }
-    }
-    
-    override func loadView() {
-        view = ParcelOrderView(delegate: self)
     }
 
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -6,61 +6,42 @@
 
 import Foundation
 
-struct ReceiverInfo {
-    let address: String
-    var receiverName: String
-    var receiverMobile: String
+// DatabaseParcelInformationPersistence와 ParcelOrderProcessor를 위한 파일을 따로 따로 만들어서 분리해야 할까요?
+
+protocol ParcelInformationPersistence {
+    func save(parcelInformation: ParcelInformation)
 }
 
-struct DeliveryCost {
-    let cost: Int
-    init(cost: Int) throws {
-        guard cost > 0 else {
-            throw NSError() as Error
-        }
-        self.cost = cost
-    }
-}
-
-class ParcelInformation {
-    var receiverInfo: ReceiverInfo
-    let deliveryCost: DeliveryCost
-    private let discount: Discount
-    var discountedCost: Int {
-        switch discount {
-        case .none:
-                return deliveryCost.cost
-        case .vip:
-                return deliveryCost.cost / 5 * 4
-        case .coupon:
-                return deliveryCost.cost / 2
-        }
-    }
-
-    init(receiverInfo: ReceiverInfo, deliveryCost: DeliveryCost, discount: Discount) {
-        self.receiverInfo = receiverInfo
-        self.deliveryCost = deliveryCost
-        self.discount = discount
-    }
-}
-
-enum Discount: Int {
-    case none = 0, vip, coupon
-}
-
-class ParcelOrderProcessor {
-    
-    // 택배 주문 처리 로직
-    func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void) {
-        
-        // 데이터베이스에 주문 저장
-        save(parcelInformation: parcelInformation)
-        
-        onComplete(parcelInformation)
-    }
+class DatabaseParcelInformationPersistence: ParcelInformationPersistence {
     
     func save(parcelInformation: ParcelInformation) {
         // 데이터베이스에 주문 정보 저장
         print("발송 정보를 데이터베이스에 저장했습니다.")
     }
+}
+
+
+
+
+protocol ParcelOrderProcessorProtocol {
+    func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void)
+}
+
+class ParcelOrderProcessor: ParcelOrderProcessorProtocol {
+    // DatabaseParcelInformationPersistence 타입 대신에 추상화 주입
+    private let parcelInformationPersistence: ParcelInformationPersistence
+    
+    init(parcelInformationPersistence: ParcelInformationPersistence) {
+        self.parcelInformationPersistence = parcelInformationPersistence
+    }
+    
+    // 택배 주문 처리 로직
+    func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void) {
+        
+        // 데이터베이스에 주문 저장
+        parcelInformationPersistence.save(parcelInformation: parcelInformation)
+        
+        onComplete(parcelInformation)
+    }
+    
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -6,27 +6,39 @@
 
 import Foundation
 
-class ParcelInformation {
+struct ReceiverInfo {
     let address: String
     var receiverName: String
     var receiverMobile: String
-    let deliveryCost: Int
+}
+
+struct DeliveryCost {
+    let cost: Int
+    init(cost: Int) throws {
+        guard cost > 0 else {
+            throw NSError() as Error
+        }
+        self.cost = cost
+    }
+}
+
+class ParcelInformation {
+    var receiverInfo: ReceiverInfo
+    let deliveryCost: DeliveryCost
     private let discount: Discount
     var discountedCost: Int {
         switch discount {
         case .none:
-            return deliveryCost
+                return deliveryCost.cost
         case .vip:
-            return deliveryCost / 5 * 4
+                return deliveryCost.cost / 5 * 4
         case .coupon:
-            return deliveryCost / 2
+                return deliveryCost.cost / 2
         }
     }
 
-    init(address: String, receiverName: String, receiverMobile: String, deliveryCost: Int, discount: Discount) {
-        self.address = address
-        self.receiverName = receiverName
-        self.receiverMobile = receiverMobile
+    init(receiverInfo: ReceiverInfo, deliveryCost: DeliveryCost, discount: Discount) {
+        self.receiverInfo = receiverInfo
         self.deliveryCost = deliveryCost
         self.discount = discount
     }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/SceneDelegate.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/SceneDelegate.swift
@@ -14,7 +14,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let scene: UIWindowScene = (scene as? UIWindowScene) else { return }
         
-        let viewController: ParcelOrderViewController = ParcelOrderViewController()
+        let viewController: ParcelOrderViewController = ParcelOrderViewController(parcelProcessor:
+                                                                                    ParcelOrderProcessor(parcelInformationPersistence:
+                                                                                                            DatabaseParcelInformationPersistence()))
         let navigationController: UINavigationController = UINavigationController(rootViewController: viewController)
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.navigationBar.tintColor = .black


### PR DESCRIPTION
@ryan-son 안녕하세요!
STEP 1 PR을 보냅니다. 


## 고민했던 점

 ### 객체미용체조 7원칙 '2개 이상의 원시타입 프로퍼티를 갖는 타입 금지'
ParcelInformation 타입이 겆는 여러 원시타잎 프로퍼티를 분리한 방법이 고민됩니다. 특히, ReceiverInfo 타입은 이 원칙을 위반하고 있기에 ReceiverInfo를 더 분리하는 것이 좋습니까?


### SOLID SRP 적용

DatabaseParcelInformationPersistence 타입을 따로 만들어서 ParcelOrderProcessor의 process 안에 데이터베이스에 주문 저장하도록 수정했습니다. 그리고 DIP 적용해서 ParcelInformationPersistence 프로토콜을 썼습니다. 
SRP와 DIP를 잘 적용했는지, ParcelOrderViewController에서도 의존성을 없애기 위헤 ParcelOrderProcessorProtocol을 주입하는 것이 맞는지 고민했습니다.


### 4원칙 한 줄에 한 점만 사용

InvoiceView에서 ParcelInformation을 쓸 때 4원칙을 지키기 위해서 ParcelInformation에서 해당값을 반환하는 함수를 만들었는데, 이보다 더 좋은 방법이 있는지 고민합니다.


### 파일 정리
ParcelProcessor.swift 파일에 DatabaseParcelInformationPersistence 타입도 들어가 있는데 혹시 파일을 따로 만들어서 분리하는 것이 더 낫겠는지도 고민했습니다.


## 조언을 얻고 싶은 부분

 ### 객체미용체조 7원칙,  SRP와 DIP
위 원칙을 적용할때 잘못한 부분에 대해서 조언을 얻고 싶습니다.