### PR TITLE
택배 송장 제조기 [STEP 2] Choiy

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		7DCE0C022B6128EB00EAA5CD /* ReceiverInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */; };
 		7DCE0C042B61298A00EAA5CD /* CostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C032B61298A00EAA5CD /* CostInformation.swift */; };
 		7DCE0C062B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C052B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift */; };
+		7DF00A922B62819900DC6DB7 /* Discount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF00A912B62819900DC6DB7 /* Discount.swift */; };
 		C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4F92B46658300A4DDC0 /* AppDelegate.swift */; };
 		C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */; };
 		C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */; };
@@ -25,6 +26,7 @@
 		7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiverInformation.swift; sourceTree = "<group>"; };
 		7DCE0C032B61298A00EAA5CD /* CostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostInformation.swift; sourceTree = "<group>"; };
 		7DCE0C052B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseParcelInformationPersistence.swift; sourceTree = "<group>"; };
+		7DF00A912B62819900DC6DB7 /* Discount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Discount.swift; sourceTree = "<group>"; };
 		C741F4F62B46658300A4DDC0 /* ParcelInvoiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParcelInvoiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C741F4F92B46658300A4DDC0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 				7DCE0C052B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift */,
 				7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */,
 				7DCE0C032B61298A00EAA5CD /* CostInformation.swift */,
+				7DF00A912B62819900DC6DB7 /* Discount.swift */,
 				C741F5022B46658400A4DDC0 /* Assets.xcassets */,
 				C741F5042B46658400A4DDC0 /* LaunchScreen.storyboard */,
 				C741F5072B46658400A4DDC0 /* Info.plist */,
@@ -156,6 +159,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7DCE0C042B61298A00EAA5CD /* CostInformation.swift in Sources */,
+				7DF00A922B62819900DC6DB7 /* Discount.swift in Sources */,
 				C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */,
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,
 				C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/CostInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/CostInformation.swift
@@ -12,22 +12,12 @@ struct CostInformation {
     private let discount: Discount
     
     var discountedCost: Int {
-        switch discount {
-        case .none:
-            return deliveryCost
-        case .vip:
-            return deliveryCost / 5 * 4
-        case .coupon:
-            return deliveryCost / 2
-        }
+        let discountStrategy: DiscountStrategy = discount.strategy
+        return discountStrategy.discountedCost(self.deliveryCost)
     }
     
     init(deliveryCost: Int, discount: Discount) {
         self.deliveryCost = deliveryCost
         self.discount = discount
     }
-}
-
-enum Discount: Int {
-    case none = 0, vip, coupon
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
@@ -1,0 +1,44 @@
+//
+//  Discount.swift
+//  ParcelInvoiceMaker
+//
+//  Created by Daegeon Choi on 2024/01/25.
+//
+
+import Foundation
+
+protocol DiscountStrategy {
+    func discountedCost(_ deliveryCost: Int) -> Int
+}
+
+struct NoDiscount: DiscountStrategy {
+    func discountedCost(_ deliveryCost: Int) -> Int {
+        return deliveryCost
+    }
+}
+
+struct VipDiscount: DiscountStrategy {
+    func discountedCost(_ deliveryCost: Int) -> Int {
+        return deliveryCost / 5 * 4
+    }
+}
+
+struct CouponDiscount: DiscountStrategy {
+    func discountedCost(_ deliveryCost: Int) -> Int {
+        return deliveryCost / 2
+    }
+}
+
+enum Discount: Int {
+    case none = 0, vip, coupon
+    var strategy: DiscountStrategy {
+        switch self {
+        case .none:
+            return NoDiscount()
+        case .vip:
+            return VipDiscount()
+        case .coupon:
+            return CouponDiscount()
+        }
+    }
+}


### PR DESCRIPTION
@KYHyeon
안녕하세요! 이번에도 잘부탁드립니다!
STEP 1에 수정했던 내역에 이어서 진행해 보았습니다 🙌

## 고민했던 점
### SOLID OCP
- STEP 1에서 `CostInformation`가 `discountedCost` 계산 프로퍼티를 소유하고 있어 이 책임을 분리할 수 있도록 고민해보았습니다.
- 기존 `discountedCost ` 계산 프로퍼티에서는 `discount`와 `deliveryCost` 두가지 데이터가 모두 필요한데, 이를 어떻게 분리해야 할지에 대해 고민했습니다.
- 뷰 컨트롤러의 코드를 수정하지 않아도 동일하게 동작할 수 있도록 구현하였습니다.

### 객체 미용 체조 2원칙 적용
- `discountedCost` 내부의 `switch`문은 제거했지만 대신 `Discount` 타입의 `strategy`프로퍼티에 `switch`가 생기게 되었는데 이를 대체할 수 있을지에 대해 고민해 보았습니다

---

## 해결하지 못한 부분
### SOLID OCP
- `discountedCost` 프로퍼티의 `switch`를 없앴지만 `strategy` 내부에 `switch`가 생겼기 때문에 OCP를 잘 준수하지 못하게 되었다고 생각했고 이를 해결하기 위해 다음과 같은 방식을 시도해 보았습니다
```swift
protocol DiscountStrategy {
    func discountedCost(_ deliveryCost: Int) -> Int
    func canApply(_ discount: Discount) -> Bool  // 새롭게 추가된 함수
}

struct NoDiscount: DiscountStrategy {

    func discountedCost(_ deliveryCost: Int) -> Int {
        return deliveryCost
    }
    
    func canApply(_ discount: Discount) -> Bool {
        return discount == .none
    }
}

struct VipDiscount: DiscountStrategy {

    func discountedCost(_ deliveryCost: Int) -> Int {
        return deliveryCost / 5 * 4
    }
    
    func canApply(_ discount: Discount) -> Bool {
        return discount == .vip
    }
}

struct CouponDiscount: DiscountStrategy {

    func discountedCost(_ deliveryCost: Int) -> Int {
        return deliveryCost / 2
    }
    
    func canApply(_ discount: Discount) -> Bool {
        return discount == .coupon
    }
}

enum Discount: Int {
    case none = 0, vip, coupon
    
    var strategy: DiscountStrategy? {
        let strategies: [DiscountStrategy] = [NoDiscount(), VipDiscount(), CouponDiscount()]
        return strategies.first { $0.canApply(self) }
    }
}
```
- 하지만 이런 방식으로 리팩토링 하게 될 경우 `strategies`에서 원하는 `DiscountStrategy `를 추출하면 `Optional` 자료형으로 리턴해야 했기 때문에 `Discount` 자료형을 사용하는 다른 코드에서도 모두 수정을 해주어야 하는 상황이 발생합니다.
- 위 방법에서는 다른 코드들에 대한 영향도가 너무 커 최선의 방법이 아닌 것을 생각 되는데, 더 좋은 방법이 있을지 조언을 구하고 싶습니다!

---

## 조언을 얻고 싶은 부분
### SOLID SRP
- `CostInformation`에 `discountCost`에 대한 로직을 분리하는데에는 성공했지만 여전히 `CostInformation` 구조체 안에 `discount`와 `discountedCost`를 여전히 같이 가지고 있어 SRP가 충분히 준수되고 있는 것인지 잘 모르겠습니다.

### 공통
- 인스턴스나 프로퍼티들을 새로운 구조체나 클래스 내부의 값으로 바꾸다 보면 뷰 컨트롤러에서 해당 데이터를 접근하는 코드 또한 수정되어야 하는 상황이 발생할 수 있는데 이런 상황이 최대한 적게 발생하는 방향으로 리팩토링을 하게 되는 것 같습니다. 외부에서 데이터를 접근하는 코드의 수정이 있더라도 필요한 객체들의 리팩토링을 우선시 하는 것이 좋은 방법일까요? 
