### PR TITLE
택배송장 [STEP Bonus] arex

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B53BEA612B63648D00C8C052 /* ParcelInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BEA602B63648D00C8C052 /* ParcelInformation.swift */; };
-		B53BEA652B63825200C8C052 /* Discount+Strategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BEA642B63825200C8C052 /* Discount+Strategy.swift */; };
+		B53BEA632B637F4300C8C052 /* Discount+Strategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BEA622B637F4300C8C052 /* Discount+Strategy.swift */; };
 		C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4F92B46658300A4DDC0 /* AppDelegate.swift */; };
 		C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */; };
 		C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */; };
@@ -22,7 +22,7 @@
 
 /* Begin PBXFileReference section */
 		B53BEA602B63648D00C8C052 /* ParcelInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformation.swift; sourceTree = "<group>"; };
-		B53BEA642B63825200C8C052 /* Discount+Strategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Discount+Strategy.swift"; sourceTree = "<group>"; };
+		B53BEA622B637F4300C8C052 /* Discount+Strategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Discount+Strategy.swift"; sourceTree = "<group>"; };
 		C741F4F62B46658300A4DDC0 /* ParcelInvoiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParcelInvoiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C741F4F92B46658300A4DDC0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -74,7 +74,7 @@
 				C741F5132B468AC300A4DDC0 /* InvoiceView.swift */,
 				C741F50D2B46659500A4DDC0 /* ParcelProcessor.swift */,
 				B53BEA602B63648D00C8C052 /* ParcelInformation.swift */,
-				B53BEA642B63825200C8C052 /* Discount+Strategy.swift */,
+				B53BEA622B637F4300C8C052 /* Discount+Strategy.swift */,
 				C741F5022B46658400A4DDC0 /* Assets.xcassets */,
 				C741F5042B46658400A4DDC0 /* LaunchScreen.storyboard */,
 				C741F5072B46658400A4DDC0 /* Info.plist */,
@@ -158,7 +158,7 @@
 				C741F50E2B46659500A4DDC0 /* ParcelProcessor.swift in Sources */,
 				C741F5102B4675AF00A4DDC0 /* InvoiceViewController.swift in Sources */,
 				C741F5122B468AA300A4DDC0 /* ParcelOrderView.swift in Sources */,
-				B53BEA652B63825200C8C052 /* Discount+Strategy.swift in Sources */,
+				B53BEA632B637F4300C8C052 /* Discount+Strategy.swift in Sources */,
 				C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */,
 				B53BEA612B63648D00C8C052 /* ParcelInformation.swift in Sources */,
 			);

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B53BEA612B63648D00C8C052 /* ParcelInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BEA602B63648D00C8C052 /* ParcelInformation.swift */; };
+		B53BEA652B63825200C8C052 /* Discount+Strategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BEA642B63825200C8C052 /* Discount+Strategy.swift */; };
 		C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4F92B46658300A4DDC0 /* AppDelegate.swift */; };
 		C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */; };
 		C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */; };
@@ -19,6 +21,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		B53BEA602B63648D00C8C052 /* ParcelInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformation.swift; sourceTree = "<group>"; };
+		B53BEA642B63825200C8C052 /* Discount+Strategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Discount+Strategy.swift"; sourceTree = "<group>"; };
 		C741F4F62B46658300A4DDC0 /* ParcelInvoiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParcelInvoiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C741F4F92B46658300A4DDC0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +73,8 @@
 				C741F50F2B4675AF00A4DDC0 /* InvoiceViewController.swift */,
 				C741F5132B468AC300A4DDC0 /* InvoiceView.swift */,
 				C741F50D2B46659500A4DDC0 /* ParcelProcessor.swift */,
+				B53BEA602B63648D00C8C052 /* ParcelInformation.swift */,
+				B53BEA642B63825200C8C052 /* Discount+Strategy.swift */,
 				C741F5022B46658400A4DDC0 /* Assets.xcassets */,
 				C741F5042B46658400A4DDC0 /* LaunchScreen.storyboard */,
 				C741F5072B46658400A4DDC0 /* Info.plist */,
@@ -152,7 +158,9 @@
 				C741F50E2B46659500A4DDC0 /* ParcelProcessor.swift in Sources */,
 				C741F5102B4675AF00A4DDC0 /* InvoiceViewController.swift in Sources */,
 				C741F5122B468AA300A4DDC0 /* ParcelOrderView.swift in Sources */,
+				B53BEA652B63825200C8C052 /* Discount+Strategy.swift in Sources */,
 				C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */,
+				B53BEA612B63648D00C8C052 /* ParcelInformation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount+Strategy.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount+Strategy.swift
@@ -1,0 +1,57 @@
+//
+//  Discount+Strategy.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 강동영 on 1/26/24.
+//
+
+import Foundation
+
+protocol DiscountStrategy {
+    func applyDiscount(to delieveryCost: Int) -> Int
+}
+
+struct NoDiscount: DiscountStrategy {
+    func applyDiscount(to delieveryCost: Int) -> Int {
+        return delieveryCost
+    }
+}
+
+struct VIPDiscount: DiscountStrategy {
+    func applyDiscount(to delieveryCost: Int) -> Int {
+        return delieveryCost / 5 * 3
+    }
+}
+
+struct CouponDiscount: DiscountStrategy {
+    func applyDiscount(to delieveryCost: Int) -> Int {
+        return delieveryCost / 2
+    }
+}
+
+struct SubscribeDiscount: DiscountStrategy {
+    func applyDiscount(to delieveryCost: Int) -> Int {
+        return delieveryCost / 5 * 4
+    }
+}
+
+enum Discount: Int {
+    case none = 0, vip, coupon, subscribe
+    var strategy: DiscountStrategy {
+        switch self {
+        case .none: return NoDiscount()
+        case .vip: return VIPDiscount()
+        case .coupon: return CouponDiscount()
+        case .subscribe: return SubscribeDiscount()
+        }
+    }
+    
+    var title: String {
+        switch self {
+        case .none: return "없음"
+        case .vip: return "VIP"
+        case .coupon: return "쿠폰"
+        case .subscribe: return "구독"
+        }
+    }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount+Strategy.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount+Strategy.swift
@@ -18,8 +18,8 @@ struct NoDiscount: DiscountStrategy {
 }
 
 struct VIPDiscount: DiscountStrategy {
-    func applyDiscount(to delieveryCost: Int) -> Int {
-        return delieveryCost / 5 * 3
+    func applyDiscount(to deliveryCost: Int) -> Int {
+        return deliveryCost / 5 * 3
     }
 }
 
@@ -32,6 +32,12 @@ struct CouponDiscount: DiscountStrategy {
 struct SubscribeDiscount: DiscountStrategy {
     func applyDiscount(to delieveryCost: Int) -> Int {
         return delieveryCost / 5 * 4
+    }
+}
+
+struct SubscribeDiscount: DiscountStrategy {
+    func applyDiscount(to deliveryCost: Int) -> Int {
+        return deliveryCost / 5 * 4
     }
 }
 

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 final class InvoiceView: UIView {
-    let parcelInformation: ParcelInformation
+    private let parcelInformation: ParcelInformation
     
     init(parcelInformation: ParcelInformation) {
         self.parcelInformation = parcelInformation
@@ -24,17 +24,17 @@ final class InvoiceView: UIView {
         let nameLabel: UILabel = UILabel()
         nameLabel.textColor = .black
         nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        nameLabel.text = "\(ParcelOrderInfo.name) : \(parcelInformation.receiverInfo.name)"
+        nameLabel.text = "\(ParcelOrderInfo.name) : \(parcelInformation.getReceiverName())"
         
         let mobileLabel: UILabel = UILabel()
         mobileLabel.textColor = .black
         mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        mobileLabel.text = "\(ParcelOrderInfo.mobile) : \(parcelInformation.receiverInfo.mobile)"
+        mobileLabel.text = "\(ParcelOrderInfo.mobile) : \(parcelInformation.getReceiverMobile())"
         
         let addressLabel: UILabel = UILabel()
         addressLabel.textColor = .black
         addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        addressLabel.text = "\(ParcelOrderInfo.address) : \(parcelInformation.receiverInfo.address)"
+        addressLabel.text = "\(ParcelOrderInfo.address) : \(parcelInformation.getReceiverAddress())"
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
@@ -24,22 +24,22 @@ final class InvoiceView: UIView {
         let nameLabel: UILabel = UILabel()
         nameLabel.textColor = .black
         nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        nameLabel.text = "이름 : \(parcelInformation.receiverInfo.name)"
+        nameLabel.text = "\(ParcelOrderInfo.name) : \(parcelInformation.receiverInfo.name)"
         
         let mobileLabel: UILabel = UILabel()
         mobileLabel.textColor = .black
         mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        mobileLabel.text = "전화 : \(parcelInformation.receiverInfo.mobile)"
+        mobileLabel.text = "\(ParcelOrderInfo.mobile) : \(parcelInformation.receiverInfo.mobile)"
         
         let addressLabel: UILabel = UILabel()
         addressLabel.textColor = .black
         addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        addressLabel.text = "주소 : \(parcelInformation.receiverInfo.address)"
+        addressLabel.text = "\(ParcelOrderInfo.address) : \(parcelInformation.receiverInfo.address)"
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black
         costLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        costLabel.text = "요금 : \(parcelInformation.discountedCost)"
+        costLabel.text = "\(ParcelOrderInfo.cost) : \(parcelInformation.discountedCost)"
                 
         let mainStackView: UIStackView = .init(arrangedSubviews: [nameLabel, mobileLabel, addressLabel, costLabel])
         mainStackView.axis = .vertical
@@ -47,7 +47,7 @@ final class InvoiceView: UIView {
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(mainStackView)
         
-        let stampImageView: UIImageView = UIImageView(image: UIImage(named: "stamp"))
+        let stampImageView: UIImageView = UIImageView(image: UIImage(named: AssetName.stamp))
         stampImageView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stampImageView)
         
@@ -78,4 +78,9 @@ final class InvoiceView: UIView {
         context.setStrokeColor(UIColor.red.cgColor)
         context.drawPath(using: .stroke)
     }
+}
+
+struct AssetName {
+    static let stamp: String = "stamp"
+    static let postOfficeLogo: String = "post_office_logo"
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceViewController.swift
@@ -13,7 +13,7 @@ final class InvoiceViewController: UIViewController {
     init(parcelInformation: ParcelInformation) {
         self.parcelInformation = parcelInformation
         super.init(nibName: nil, bundle: nil)
-        navigationItem.title = "송장정보"
+        navigationItem.title = InvoiceMessage.title
     }
     
     required init?(coder: NSCoder) {
@@ -24,4 +24,12 @@ final class InvoiceViewController: UIViewController {
         view = InvoiceView(parcelInformation: parcelInformation)
     }
     
+}
+
+protocol Titleable {
+    static var title: String { get }
+}
+
+struct InvoiceMessage: Titleable {
+    static let title: String = "송장정보"
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
@@ -1,0 +1,78 @@
+//
+//  ParcelInformation.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 강동영 on 1/26/24.
+//
+
+import Foundation
+
+final class ParcelInformation {
+    private var receiverInfo: ReceiverInfo
+    let deliveryCost: Int
+    private let discount: Discount
+    var discountedCost: Int {
+        return discount.strategy.applyDiscount(to: deliveryCost)
+    }
+
+    init(receiverInfo: ReceiverInfo, deliveryCost: Int, discount: Discount) {
+        self.receiverInfo = receiverInfo
+        self.deliveryCost = deliveryCost
+        self.discount = discount
+    }
+    
+    func getReceiverAddress() -> String {
+        return receiverInfo.getAddress()
+    }
+    
+    func getReceiverName() -> String {
+        return receiverInfo.getName()
+    }
+    
+    func getReceiverMobile() -> String {
+        return receiverInfo.getMobile().description
+    }
+}
+
+struct ReceiverInfo {
+    private let address: String
+    private var name: String
+    private var mobile: MobileNumber
+    
+    init(address: String, name: String, mobile: MobileNumber) {
+        self.address = address
+        self.name = name
+        self.mobile = mobile
+    }
+    
+    func getAddress() -> String {
+        return address
+    }
+    
+    func getName() -> String {
+        return name
+    }
+    
+    func getMobile() -> MobileNumber {
+        return mobile
+    }
+}
+
+struct MobileNumber: CustomStringConvertible {
+    private let value: String
+    init(value: String) throws {
+        guard Self.valid(with: value) == true else {
+            throw NSError() as Error
+        }
+        self.value = value
+    }
+    
+    static func valid(with number: String) -> Bool {
+        return NSPredicate(format: "SELF MATCHES %@",
+                           #"^01[016789]\d{3,4}\d{4}$"#).evaluate(with: number)
+    }
+    
+    var description: String {
+        return value
+    }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
@@ -59,10 +59,11 @@ struct ReceiverInfo {
 }
 
 struct MobileNumber: CustomStringConvertible {
-    private let value: String
-    init(value: String) throws {
+    private let value: String?
+    init(value: String) {
         guard Self.valid(with: value) == true else {
-            throw NSError() as Error
+            self.value = nil
+            return
         }
         self.value = value
     }
@@ -73,6 +74,6 @@ struct MobileNumber: CustomStringConvertible {
     }
     
     var description: String {
-        return value
+        return value ?? ""
     }
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -86,18 +86,14 @@ final class ParcelOrderView: UIView {
             return
         }
         
-        do {
-            let mobileNumber: MobileNumber = try .init(value: mobile)
-            let receiverInfo: ReceiverInfo = .init(address: address,
-                                                   name: name,
-                                                   mobile: mobileNumber)
-            let parcelInformation: ParcelInformation = .init(receiverInfo: receiverInfo,
-                                                             deliveryCost: cost,
-                                                             discount: discount)
-            delegate.parcelOrderMade(parcelInformation)
-        } catch {
-            throw error
-        }
+        let mobileNumber: MobileNumber = .init(value: mobile)
+        let receiverInfo: ReceiverInfo = .init(address: address,
+                                               name: name,
+                                               mobile: mobileNumber)
+        let parcelInformation: ParcelInformation = .init(receiverInfo: receiverInfo,
+                                                         deliveryCost: cost,
+                                                         discount: discount)
+        delegate.parcelOrderMade(parcelInformation)
     }
     
     private func layoutView() {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -184,7 +184,7 @@ final class ParcelOrderView: UIView {
     }
 }
 
-struct ParcelOrderInfo {
+enum ParcelOrderInfo {
     static let name: String = "이름"
     static let mobile: String = "전화"
     static let address: String = "주소"

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -42,10 +42,10 @@ final class ParcelOrderView: UIView {
     
     private let discountSegmented: UISegmentedControl = {
         let control: UISegmentedControl = .init()
-        control.insertSegment(withTitle: Discount.noneTitle, at: 0, animated: false)
-        control.insertSegment(withTitle: Discount.vipTitle, at: 1, animated: false)
-        control.insertSegment(withTitle: Discount.couponTitle, at: 2, animated: false)
-        control.insertSegment(withTitle: Discount.subscribeTitle, at: 3, animated: false)
+        control.insertSegment(withTitle: Discount.none.title, at: 0, animated: false)
+        control.insertSegment(withTitle: Discount.vip.title, at: 1, animated: false)
+        control.insertSegment(withTitle: Discount.coupon.title, at: 2, animated: false)
+        control.insertSegment(withTitle: Discount.subscribe.title, at: 3, animated: false)
         control.selectedSegmentIndex = 0
         return control
     }()

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -42,9 +42,18 @@ final class ParcelOrderView: UIView {
     
     private let discountSegmented: UISegmentedControl = {
         let control: UISegmentedControl = .init()
-        control.insertSegment(withTitle: "없음", at: 0, animated: false)
-        control.insertSegment(withTitle: "VIP", at: 1, animated: false)
-        control.insertSegment(withTitle: "쿠폰", at: 2, animated: false)
+        control.insertSegment(withTitle: Discount.noneTitle, at: 0, animated: false)
+        control.insertSegment(withTitle: Discount.vipTitle, at: 1, animated: false)
+        control.insertSegment(withTitle: Discount.couponTitle, at: 2, animated: false)
+        control.insertSegment(withTitle: Discount.subscribeTitle, at: 3, animated: false)
+        control.selectedSegmentIndex = 0
+        return control
+    }()
+    
+    private let receiptSegmented: UISegmentedControl = {
+        let control: UISegmentedControl = .init()
+        control.insertSegment(withTitle: Receipt.emailTitle, at: 0, animated: false)
+        control.insertSegment(withTitle: Receipt.smsTitle, at: 1, animated: false)
         control.selectedSegmentIndex = 0
         return control
     }()
@@ -93,37 +102,42 @@ final class ParcelOrderView: UIView {
     
     private func layoutView() {
         
-        let logoImageView: UIImageView = UIImageView(image: UIImage(named: "post_office_logo"))
+        let logoImageView: UIImageView = UIImageView(image: UIImage(named: AssetName.postOfficeLogo))
         logoImageView.contentMode = .scaleAspectFit
         
         let nameLabel: UILabel = UILabel()
         nameLabel.textColor = .black
-        nameLabel.text = "이름"
+        nameLabel.text = ParcelOrderInfo.name
         nameLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         
         let mobileLabel: UILabel = UILabel()
         mobileLabel.textColor = .black
-        mobileLabel.text = "전화"
+        mobileLabel.text = ParcelOrderInfo.mobile
         mobileLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         
         let addressLabel: UILabel = UILabel()
         addressLabel.textColor = .black
-        addressLabel.text = "주소"
+        addressLabel.text = ParcelOrderInfo.address
         addressLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black
-        costLabel.text = "요금"
+        costLabel.text = ParcelOrderInfo.cost
         costLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         
         let discountLabel: UILabel = UILabel()
         discountLabel.textColor = .black
-        discountLabel.text = "할인"
+        discountLabel.text = ParcelOrderInfo.discount
         discountLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        
+        let receiptLabel: UILabel = UILabel()
+        receiptLabel.textColor = .black
+        receiptLabel.text = ParcelOrderInfo.discount
+        receiptLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         
         let notificationLabel: UILabel = UILabel()
         notificationLabel.textColor = .black
-        notificationLabel.text = "알림"
+        notificationLabel.text = ParcelOrderInfo.notification
         notificationLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         
         let nameStackView: UIStackView = .init(arrangedSubviews: [nameLabel, receiverNameField])
@@ -147,12 +161,16 @@ final class ParcelOrderView: UIView {
         discountStackView.spacing = 8
         discountStackView.axis = .horizontal
         
+        let receiptStackView: UIStackView = .init(arrangedSubviews: [notificationLabel, receiptSegmented])
+        receiptStackView.spacing = 8
+        receiptStackView.axis = .horizontal
+        
         let makeOrderButton: UIButton = UIButton(type: .system)
         makeOrderButton.backgroundColor = .white
-        makeOrderButton.setTitle("택배 보내기", for: .normal)
+        makeOrderButton.setTitle(ParcelOrderMessage.sendParcel, for: .normal)
         makeOrderButton.addTarget(self, action: #selector(touchUpOrderButton), for: .touchUpInside)
         
-        let mainStackView: UIStackView = .init(arrangedSubviews: [logoImageView, nameStackView, mobileStackView, addressStackView, costStackView, discountStackView, makeOrderButton])
+        let mainStackView: UIStackView = .init(arrangedSubviews: [logoImageView, nameStackView, mobileStackView, addressStackView, costStackView, discountStackView, receiptStackView, makeOrderButton])
         mainStackView.axis = .vertical
         mainStackView.distribution = .fillEqually
         mainStackView.spacing = 8
@@ -165,7 +183,16 @@ final class ParcelOrderView: UIView {
             mainStackView.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 16),
             mainStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 16),
             mainStackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -16),
-            mainStackView.bottomAnchor.constraint(lessThanOrEqualTo: safeArea.bottomAnchor, constant: -16)
+            mainStackView.bottomAnchor.constraint(lessThanOrEqualTo: safeArea.bottomAnchor, constant: -8)
         ])
     }
+}
+
+struct ParcelOrderInfo {
+    static let name: String = "이름"
+    static let mobile: String = "전화"
+    static let address: String = "주소"
+    static let cost: String = "요금"
+    static let discount: String = "할인"
+    static let notification: String = "알림"
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -28,7 +28,7 @@ final class ParcelOrderViewController: UIViewController {
 extension ParcelOrderViewController: ParcelOrderViewDelegate {
     func parcelOrderMade(_ parcelInformation: ParcelInformation) {
         parcelProcessor.process(parcelInformation: parcelInformation) { (parcelInformation) in
-            parcelProcessor.sendRecipt(parcelInformation: parcelInformation)
+            parcelProcessor.sendReceipt(parcelInformation: parcelInformation)
             let invoiceViewController: InvoiceViewController = .init(parcelInformation: parcelInformation)
             navigationController?.pushViewController(invoiceViewController, animated: true)
         }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -12,7 +12,7 @@ final class ParcelOrderViewController: UIViewController {
     init(processor: OrderProcessable) {
         self.parcelProcessor = processor
         super.init(nibName: nil, bundle: nil)
-        navigationItem.title = "택배보내기"
+        navigationItem.title = ParcelOrderMessage.title
     }
     
     required init?(coder: NSCoder) {
@@ -28,9 +28,14 @@ final class ParcelOrderViewController: UIViewController {
 extension ParcelOrderViewController: ParcelOrderViewDelegate {
     func parcelOrderMade(_ parcelInformation: ParcelInformation) {
         parcelProcessor.process(parcelInformation: parcelInformation) { (parcelInformation) in
+            parcelProcessor.sendRecipt(parcelInformation: parcelInformation)
             let invoiceViewController: InvoiceViewController = .init(parcelInformation: parcelInformation)
             navigationController?.pushViewController(invoiceViewController, animated: true)
         }
     }
 }
 
+struct ParcelOrderMessage: Titleable {
+    static let title: String = "택배보내기"
+    static let sendParcel: String = "택배 보내기"
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -6,95 +6,6 @@
 
 import Foundation
 
-struct ReceiverInfo {
-    let address: String
-    var name: String
-    var mobile: MobileNumber
-}
-
-struct MobileNumber {
-    let value: String
-    init(value: String) throws {
-        let mobileNumberRegex = #"^01[016789]\d{3,4}\d{4}$"#
-        
-        guard NSPredicate(format: "SELF MATCHES %@", mobileNumberRegex).evaluate(with: value) == true else {
-            throw NSError() as Error
-        }
-        self.value = value
-    }
-    
-    static func valid(with number: String) -> Bool {
-        return NSPredicate(format: "SELF MATCHES %@",
-                           #"^01[016789]\d{3,4}\d{4}$"#).evaluate(with: number)
-    }
-}
-
-extension MobileNumber: CustomStringConvertible {
-    var description: String {
-        return value
-    }
-}
-
-final class ParcelInformation {
-    var receiverInfo: ReceiverInfo
-    let deliveryCost: Int
-    private let discount: Discount
-    var discountedCost: Int {
-        return discount.strategy.applyDiscount(delieveryCost: deliveryCost)
-    }
-
-    init(receiverInfo: ReceiverInfo, deliveryCost: Int, discount: Discount) {
-        self.receiverInfo = receiverInfo
-        self.deliveryCost = deliveryCost
-        self.discount = discount
-    }
-}
-
-protocol DiscountStrategy {
-    func applyDiscount(delieveryCost: Int) -> Int
-}
-
-struct NoDiscount: DiscountStrategy {
-    func applyDiscount(delieveryCost: Int) -> Int {
-        return delieveryCost
-    }
-}
-
-struct VIPDiscount: DiscountStrategy {
-    func applyDiscount(delieveryCost: Int) -> Int {
-        return delieveryCost / 5 * 3
-    }
-}
-
-struct CouponDiscount: DiscountStrategy {
-    func applyDiscount(delieveryCost: Int) -> Int {
-        return delieveryCost / 2
-    }
-}
-
-struct SubscribeDiscount: DiscountStrategy {
-    func applyDiscount(delieveryCost: Int) -> Int {
-        return delieveryCost / 5 * 4
-    }
-}
-
-enum Discount: Int {
-    static let noneTitle: String = "없음"
-    static let vipTitle: String = "VIP"
-    static let couponTitle: String = "쿠폰"
-    static let subscribeTitle: String = "구독"
-    
-    case none = 0, vip, coupon, subscribe
-    var strategy: DiscountStrategy {
-        switch self {
-        case .none: return NoDiscount()
-        case .vip: return VIPDiscount()
-        case .coupon: return CouponDiscount()
-        case .subscribe: return SubscribeDiscount()
-        }
-    }
-}
-
 enum Receipt {
     static let emailTitle: String = "이메일"
     static let smsTitle: String = "문자"
@@ -126,7 +37,7 @@ final class ParcelOrderProcessor: OrderProcessable {
     }
 }
 
-protocol ParcelInformationPersistence: AnyObject {
+protocol ParcelInformationPersistence {
     func save(parcelInformation: ParcelInformation)
     func sendReceipt(parcelInformation: ParcelInformation)
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -62,7 +62,7 @@ struct NoDiscount: DiscountStrategy {
 
 struct VIPDiscount: DiscountStrategy {
     func applyDiscount(delieveryCost: Int) -> Int {
-        return delieveryCost / 5 * 4
+        return delieveryCost / 5 * 3
     }
 }
 
@@ -72,20 +72,38 @@ struct CouponDiscount: DiscountStrategy {
     }
 }
 
+struct SubscribeDiscount: DiscountStrategy {
+    func applyDiscount(delieveryCost: Int) -> Int {
+        return delieveryCost / 5 * 4
+    }
+}
+
 enum Discount: Int {
-    case none = 0, vip, coupon
+    static let noneTitle: String = "없음"
+    static let vipTitle: String = "VIP"
+    static let couponTitle: String = "쿠폰"
+    static let subscribeTitle: String = "구독"
+    
+    case none = 0, vip, coupon, subscribe
     var strategy: DiscountStrategy {
         switch self {
         case .none: return NoDiscount()
         case .vip: return VIPDiscount()
         case .coupon: return CouponDiscount()
+        case .subscribe: return SubscribeDiscount()
         }
     }
+}
+
+enum Receipt {
+    static let emailTitle: String = "이메일"
+    static let smsTitle: String = "문자"
 }
 
 protocol OrderProcessable {
     var persistence: ParcelInformationPersistence { get }
     func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void)
+    func sendRecipt(parcelInformation: ParcelInformation)
 }
 
 final class ParcelOrderProcessor: OrderProcessable {
@@ -99,22 +117,37 @@ final class ParcelOrderProcessor: OrderProcessable {
         
         // 데이터베이스에 주문 저장
         persistence.save(parcelInformation: parcelInformation)
-        
         onComplete(parcelInformation)
+    }
+    
+    // 택배 주문 처리 완료 후 영수증 전송
+    func sendRecipt(parcelInformation: ParcelInformation) {
+        persistence.sendReceipt(parcelInformation: parcelInformation)
     }
 }
 
 protocol ParcelInformationPersistence: AnyObject {
     func save(parcelInformation: ParcelInformation)
+    func sendReceipt(parcelInformation: ParcelInformation)
 }
 
 extension ParcelInformationPersistence {
     func save(parcelInformation: ParcelInformation) {
         // 데이터베이스에 주문 정보 저장
-        print("발송 정보를 데이터베이스에 저장했습니다.")
+        print(PersistenceMessage.saveParcelInformation)
+    }
+    
+    func sendReceipt(parcelInformation: ParcelInformation) {
+        // 영수증 발송
+        print(PersistenceMessage.sendReceipt)
     }
 }
 
 final class DatabaseParcelInformationPersistence: ParcelInformationPersistence {
     static let shared: DatabaseParcelInformationPersistence = DatabaseParcelInformationPersistence()
+}
+
+struct PersistenceMessage {
+    static let saveParcelInformation: String = "발송 정보를 데이터베이스에 저장했습니다."
+    static let sendReceipt: String = "영수증을 발송했습니다."
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -14,7 +14,7 @@ enum Receipt {
 protocol OrderProcessable {
     var persistence: ParcelInformationPersistence { get }
     func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void)
-    func sendRecipt(parcelInformation: ParcelInformation)
+    func sendReceipt(parcelInformation: ParcelInformation)
 }
 
 final class ParcelOrderProcessor: OrderProcessable {
@@ -32,7 +32,7 @@ final class ParcelOrderProcessor: OrderProcessable {
     }
     
     // 택배 주문 처리 완료 후 영수증 전송
-    func sendRecipt(parcelInformation: ParcelInformation) {
+    func sendReceipt(parcelInformation: ParcelInformation) {
         persistence.sendReceipt(parcelInformation: parcelInformation)
     }
 }


### PR DESCRIPTION
@GREENOVER 

늦게 PR 올렸는데, 추가 구현까지 해서 리뷰 양이 많습니다 😅🙇🏻‍♂️

- 3원칙 - 원시값과 문자열의 포장에 대한 수정이 제일 많은 것 같습니다 !

## 고민했던 점
### 영수증 발송 기능
 > 택배를 부칠 때 영수증을 [이메일], [문자] 중 어느 것으로 받을지 선택받고, 택배 프로세서가 일을 처리하면서 영수증도 발송할 수 있도록 기능을 추가해봅니다.
 
 일을 처리하면서 영수증도 발송할 수 있다는 말이 데이터베이스에 주문 저장 완료 여부와 상관 없어도 될까요 ?
 저는 영수증은 처리가 끝난 뒤에 발송하는게 맞다고 생각해서 `process` 메서드 내부가 아닌 `ParcelOrderViewController` `process` 호출 후 `completion` 처리하는 부분에 영수증 발송 기능을 호출하고 있습니다.
 
 제가 요구사항을 바르게 이해한게 맞을까 궁금합니다 ! 🧐
 
 ```swift
// 택배 주문 처리 로직
func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void) {
    // 데이터베이스에 주문 저장
    persistence.save(parcelInformation: parcelInformation)
    onComplete(parcelInformation)
}
 ```
 
 ```swift
 extension ParcelOrderViewController: ParcelOrderViewDelegate {
    func parcelOrderMade(_ parcelInformation: ParcelInformation) {
        parcelProcessor.process(parcelInformation: parcelInformation) { (parcelInformation) in
            parcelProcessor.sendRecipt(parcelInformation: parcelInformation) // < - here
            let invoiceViewController: InvoiceViewController = .init(parcelInformation: parcelInformation)
            navigationController?.pushViewController(invoiceViewController, animated: true)
        }
    }
}
 ```
 