### PR TITLE
택배송장 [STEP 2] kodirbek

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		81AFFC192B613A59002C62DC /* ParcelInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81AFFC182B613A59002C62DC /* ParcelInformation.swift */; };
+		9112B4D22B636027000D985C /* Discount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9112B4D12B636027000D985C /* Discount.swift */; };
 		C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4F92B46658300A4DDC0 /* AppDelegate.swift */; };
 		C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */; };
 		C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */; };
@@ -21,6 +22,7 @@
 
 /* Begin PBXFileReference section */
 		81AFFC182B613A59002C62DC /* ParcelInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformation.swift; sourceTree = "<group>"; };
+		9112B4D12B636027000D985C /* Discount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Discount.swift; sourceTree = "<group>"; };
 		C741F4F62B46658300A4DDC0 /* ParcelInvoiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParcelInvoiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C741F4F92B46658300A4DDC0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -66,6 +68,7 @@
 			children = (
 				C741F4F92B46658300A4DDC0 /* AppDelegate.swift */,
 				C741F4FB2B46658300A4DDC0 /* SceneDelegate.swift */,
+				9112B4D12B636027000D985C /* Discount.swift */,
 				81AFFC182B613A59002C62DC /* ParcelInformation.swift */,
 				C741F50D2B46659500A4DDC0 /* ParcelProcessor.swift */,
 				C741F4FD2B46658300A4DDC0 /* ParcelOrderViewController.swift */,
@@ -151,6 +154,7 @@
 			files = (
 				81AFFC192B613A59002C62DC /* ParcelInformation.swift in Sources */,
 				C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */,
+				9112B4D22B636027000D985C /* Discount.swift in Sources */,
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,
 				C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */,
 				C741F50E2B46659500A4DDC0 /* ParcelProcessor.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
@@ -1,0 +1,66 @@
+//
+//  Discount.swift
+//  ParcelInvoiceMaker
+//
+//  Created by TelosMac on 1/26/24.
+//
+
+import Foundation
+
+// Discount types and rates
+enum Discount: Int {
+    case none = 0, vip, coupon, holiday
+    
+    var rate: Double {
+           switch self {
+           case .none:
+               return 1 // no discount
+           case .vip:
+               return 0.8  // 20% discount
+           case .coupon:
+               return 0.5  // 50% discount
+           case .holiday:
+               return 0.85  // 15% discount
+           }
+       }
+}
+
+
+// Discount Strategy Protocol
+protocol DiscountStrategy {
+    func applyDiscount(deliveryCost: DeliveryCost, discountRate: Double) -> Int
+    func canAccept(discount: Discount) -> Bool
+}
+
+extension DiscountStrategy {
+    func applyDiscount(deliveryCost: DeliveryCost, discountRate: Double) -> Int {
+        Int(deliveryCost.cost * discountRate)
+    }
+}
+
+
+// Discount Strategies
+struct NoDiscount: DiscountStrategy {
+    func canAccept(discount: Discount) -> Bool {
+        return discount == .none
+    }
+}
+
+struct VIPDiscount: DiscountStrategy {
+    func canAccept(discount: Discount) -> Bool {
+        return discount == .vip
+    }
+}
+
+struct CouponDiscount: DiscountStrategy {
+    func canAccept(discount: Discount) -> Bool {
+        return discount == .coupon
+    }
+}
+
+// 이 새로운 전략은 테스트로 추가했습니다.
+struct HolidayDiscount: DiscountStrategy {
+    func canAccept(discount: Discount) -> Bool {
+        return discount == .holiday
+    }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
@@ -24,17 +24,17 @@ class InvoiceView: UIView {
         let nameLabel: UILabel = UILabel()
         nameLabel.textColor = .black
         nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        nameLabel.text = "이름 : \(parcelInformation.getReceiverName())"
+        nameLabel.text = "이름 : \(parcelInformation.receiver.name)"
         
         let mobileLabel: UILabel = UILabel()
         mobileLabel.textColor = .black
         mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        mobileLabel.text = "전화 : \(parcelInformation.getReceiverMobile())"
+        mobileLabel.text = "전화 : \(parcelInformation.receiver.mobile)"
         
         let addressLabel: UILabel = UILabel()
         addressLabel.textColor = .black
         addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        addressLabel.text = "주소 : \(parcelInformation.getReceiverAddress())"
+        addressLabel.text = "주소 : \(parcelInformation.addressInfo.address)"
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
@@ -118,7 +118,7 @@ struct DiscountCostCalculator {
     func getDiscountedCost() -> Int {
         discountStrategies.filter {$0.canAccept(discount: discount)}
             .first?
-            .applyDiscount(deliveryCost: deliveryCost, discountRate: discount.rate) ?? 0
+            .applyDiscount(deliveryCost: deliveryCost, discountRate: discount.rate) ?? Int(deliveryCost.cost)
     }
 }
 

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
@@ -21,7 +21,7 @@ protocol DiscountStrategy {
 struct NoDiscount: DiscountStrategy {
     private var noDiscount: Double = 1
     func applyDiscount(deliveryCost: DeliveryCost) -> Int {
-        Int(deliveryCost.getCost())
+        Int(deliveryCost.cost)
     }
     func canAccept(discount: Discount) -> Bool {
         return discount == .none
@@ -31,7 +31,7 @@ struct NoDiscount: DiscountStrategy {
 struct VIPDiscount: DiscountStrategy {
     private let twentyPerDiscount: Double = 0.8
     func applyDiscount(deliveryCost: DeliveryCost) -> Int {
-        Int(deliveryCost.getCost() * twentyPerDiscount)
+        Int(deliveryCost.cost * twentyPerDiscount)
     }
     func canAccept(discount: Discount) -> Bool {
         return discount == .vip
@@ -41,7 +41,7 @@ struct VIPDiscount: DiscountStrategy {
 struct CouponDiscount: DiscountStrategy {
     private let fiftyPerDiscount: Double = 0.5
     func applyDiscount(deliveryCost: DeliveryCost) -> Int {
-        Int(deliveryCost.getCost() * fiftyPerDiscount)
+        Int(deliveryCost.cost * fiftyPerDiscount)
     }
     func canAccept(discount: Discount) -> Bool {
         return discount == .coupon
@@ -52,7 +52,7 @@ struct CouponDiscount: DiscountStrategy {
 struct HolidayDiscount: DiscountStrategy {
     private let fifteenPerDiscount: Double = 0.85
     func applyDiscount(deliveryCost: DeliveryCost) -> Int {
-        Int(Double(deliveryCost.getCost()) * fifteenPerDiscount)
+        Int(Double(deliveryCost.cost) * fifteenPerDiscount)
     }
     func canAccept(discount: Discount) -> Bool {
         return discount == .holiday
@@ -64,56 +64,40 @@ struct HolidayDiscount: DiscountStrategy {
 
 // cost가 음수 또는 0이 아닌지 확인하기 위해 init()에서 배송 비용을 검증합니다.
 struct DeliveryCost {
-    private var cost: Double
+    private(set) var cost: Double
     
-    private static func validate(_ cost: Double) throws {
-        guard cost > 0 else {
-            throw NSError() as Error
+    private static func validate(_ cost: Double) -> Bool {
+        return cost >= 0
+    }
+    
+    init?(_ cost: Double) {
+        guard Self.validate(cost) else {
+            print("Invalid cost: Cost must be greater than or equal to 0.")
+            return nil
         }
-    }
-    
-    init(_ cost: Double) throws {
-        try Self.validate(cost)
         self.cost = cost
-    }
-    
-    func getCost() -> Double {
-        cost
     }
 }
 
 
 // MARK: - Parcel Information
 struct Address {
-    private let address: String
+    private(set) var address: String
     
     init(_ address: String) {
         self.address = address
     }
-    
-    func getAddress() -> String {
-        return address
-    }
 }
 
 
-struct ReceiverInfo {
-    private let name: String
-    private let mobile: String
+struct Receiver {
+    private(set) var name: String
+    private(set) var mobile: String
     
     init(name: String, mobile: String) {
         self.name = name
         self.mobile = mobile
     }
-    
-    func getName() -> String{
-        return name
-    }
-    
-    func getMobile() -> String {
-        return mobile
-    }
-    
 }
 
 // 원칙 2 'else 사용 금지'에서 볼 수 있듯이 여기에서는 전략 패턴을 사용했습니다. DiscountedCost와 ParcelInformation를 변경하지 않고도 쉽게 할인 유형을 확장할 수 있다는 장점이 있습니다. 테스트로 "HolidayDiscount"라는 새로운 유형의 할인 정책을 추가했습니다. 디스카운트 전략(DiscountStrategy) 프로토콜을 준수하는 새로운 HolidayDiscount 구조체를 생성했고, Discount 열거형에 새로운 'holiday' 케이스를 추가했고, 마지막으로 ParcelOrderView의 currentDiscountStrategies 배열에 새로운 전략을 추가하는 것만으로만 충분했습니다. 여기서 OCP를 따르는 것의 장점을 느꼈습니다.
@@ -128,42 +112,26 @@ struct DiscountedCost {
         self.discountStrategies = discountStrategies
     }
     
-    private var discountedCost: Int {
+    func getDiscountedCost() -> Int {
         discountStrategies.filter {$0.canAccept(discount: discount)}
             .first?
             .applyDiscount(deliveryCost: deliveryCost) ?? 0
-    }
-    
-    func getDiscountedCost() -> Int {
-        discountedCost
     }
 }
 
 
 struct ParcelInformation {
-    private let address: Address
-    private let receiverInfo: ReceiverInfo
-    private let discountedCost: DiscountedCost
+    private(set) var addressInfo: Address
+    private(set) var receiver: Receiver
+    private(set) var discountedCost: DiscountedCost
     
-    init(address: Address, receiverInfo: ReceiverInfo, discountedCost: DiscountedCost) {
-        self.address = address
-        self.receiverInfo = receiverInfo
+    init(address: Address, receiverInfo: Receiver, discountedCost: DiscountedCost) {
+        self.addressInfo = address
+        self.receiver = receiverInfo
         self.discountedCost = discountedCost
     }
     
     // InvoiceView 안에선 '4원칙: 한 줄에 한 점만 사용'을 지키기 위해서 함수 추가
-    func getReceiverName() -> String {
-        receiverInfo.getName()
-    }
-    
-    func getReceiverAddress() -> String {
-        address.getAddress()
-    }
-    
-    func getReceiverMobile() -> String {
-        receiverInfo.getMobile()
-    }
-    
     func getDiscountedCost() -> Int {
         discountedCost.getDiscountedCost()
     }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
@@ -7,82 +7,155 @@
 
 import Foundation
 
+// MARK: - Discount Strategies
+
 enum Discount: Int {
-    case none = 0, vip, coupon
+    case none = 0, vip, coupon, holiday
 }
 
-struct ReceiverInfo {
-    let address: String
-    let receiverName: String
-    let receiverMobile: String
+protocol DiscountStrategy {
+    func applyDiscount(deliveryCost: DeliveryCost) -> Int
+    func canAccept(discount: Discount) -> Bool
 }
 
+struct NoDiscount: DiscountStrategy {
+    private var noDiscount: Double = 1
+    func applyDiscount(deliveryCost: DeliveryCost) -> Int {
+        Int(deliveryCost.getCost())
+    }
+    func canAccept(discount: Discount) -> Bool {
+        return discount == .none
+    }
+}
+
+struct VIPDiscount: DiscountStrategy {
+    private let twentyPerDiscount: Double = 0.8
+    func applyDiscount(deliveryCost: DeliveryCost) -> Int {
+        Int(deliveryCost.getCost() * twentyPerDiscount)
+    }
+    func canAccept(discount: Discount) -> Bool {
+        return discount == .vip
+    }
+}
+
+struct CouponDiscount: DiscountStrategy {
+    private let fiftyPerDiscount: Double = 0.5
+    func applyDiscount(deliveryCost: DeliveryCost) -> Int {
+        Int(deliveryCost.getCost() * fiftyPerDiscount)
+    }
+    func canAccept(discount: Discount) -> Bool {
+        return discount == .coupon
+    }
+}
+
+// 이 새로운 전략은 테스트로 추가되었습니다.
+struct HolidayDiscount: DiscountStrategy {
+    private let fifteenPerDiscount: Double = 0.85
+    func applyDiscount(deliveryCost: DeliveryCost) -> Int {
+        Int(Double(deliveryCost.getCost()) * fifteenPerDiscount)
+    }
+    func canAccept(discount: Discount) -> Bool {
+        return discount == .holiday
+    }
+}
+
+
+// MARK: - Delivery Cost
+
+// cost가 음수 또는 0이 아닌지 확인하기 위해 init()에서 배송 비용을 검증합니다.
 struct DeliveryCost {
-    private var cost: Int
+    private var cost: Double
     
-    private static func validate(_ cost: Int) throws {
+    private static func validate(_ cost: Double) throws {
         guard cost > 0 else {
             throw NSError() as Error
         }
     }
     
-    init(_ cost: Int) throws {
+    init(_ cost: Double) throws {
         try Self.validate(cost)
         self.cost = cost
     }
     
-    func getCost() -> Int {
+    func getCost() -> Double {
         cost
     }
 }
 
-struct DiscountedCost {
-    static let fiftyPerDiscount: Double = 0.5
-    static let twentyPerDiscount: Double = 0.8
+
+// MARK: - Parcel Information
+struct ReceiverInfo {
+    private let address: String
+    private let receiverName: String
+    private let receiverMobile: String
     
-    static func getDiscountedCost(deliveryCost: DeliveryCost, discount: Discount) -> Int {
-        switch discount {
-            case .none:
-                return deliveryCost.getCost()
-            case .vip:
-                return Int(Double(deliveryCost.getCost()) * twentyPerDiscount)
-            case .coupon:
-                return Int(Double(deliveryCost.getCost()) * fiftyPerDiscount)
-        }
+    init(address: String, receiverName: String, receiverMobile: String) {
+        self.address = address
+        self.receiverName = receiverName
+        self.receiverMobile = receiverMobile
+    }
+    
+    func getName() -> String{
+        return receiverName
+    }
+    
+    func getMobile() -> String {
+        return receiverMobile
+    }
+    
+    func getAddress() -> String {
+        return address
     }
 }
 
-
-class ParcelInformation {
-    private let receiverInfo: ReceiverInfo
+// 원칙 2 'else 사용 금지'에서 볼 수 있듯이 여기에서는 전략 패턴을 사용했습니다. DiscountedCost와 ParcelInformation를 변경하지 않고도 쉽게 할인 유형을 확장할 수 있다는 장점이 있습니다. 테스트로 "HolidayDiscount"라는 새로운 유형의 할인 정책을 추가했습니다. 디스카운트 전략(DiscountStrategy) 프로토콜을 준수하는 새로운 HolidayDiscount 구조체를 생성했고, Discount 열거형에 새로운 'holiday' 케이스를 추가했고, 마지막으로 ParcelOrderView의 currentDiscountStrategies 배열에 새로운 전략을 추가하는 것만으로만 충분했습니다. 여기서 OCP를 따르는 것의 장점을 느꼈습니다.
+struct DiscountedCost {
     private let deliveryCost: DeliveryCost
     private let discount: Discount
+    private let discountStrategies: [DiscountStrategy]
     
-    private var discountedCost: Int {
-        DiscountedCost.getDiscountedCost(deliveryCost: deliveryCost, discount: discount)
-    }
-    
-    init(receiverInfo: ReceiverInfo, deliveryCost: DeliveryCost, discount: Discount) {
-        self.receiverInfo = receiverInfo
+    init(deliveryCost: DeliveryCost, discount: Discount, discountStrategies: [DiscountStrategy]) {
         self.deliveryCost = deliveryCost
         self.discount = discount
+        self.discountStrategies = discountStrategies
     }
     
-    // InvoiceView 안에선 '4원칙: 한 줄에 한 점만 사용'을 지키기 위해서 함수 추가
-    func getReceiverName() -> String {
-        receiverInfo.receiverName
-    }
-    
-    func getReceiverAddress() -> String {
-        receiverInfo.address
-    }
-    
-    func getReceiverMobile() -> String {
-        receiverInfo.receiverMobile
+    private var discountedCost: Int {
+        discountStrategies.filter {$0.canAccept(discount: discount)}
+            .first?
+            .applyDiscount(deliveryCost: deliveryCost) ?? 0
     }
     
     func getDiscountedCost() -> Int {
         discountedCost
+    }
+}
+
+
+struct ParcelInformation {
+    private let receiverInfo: ReceiverInfo
+    private let discountedCost: DiscountedCost
+    
+    init(receiverInfo: ReceiverInfo, discountedCost: DiscountedCost) {
+        self.receiverInfo = receiverInfo
+        self.discountedCost = discountedCost
+    }
+    
+    // InvoiceView 안에선 '4원칙: 한 줄에 한 점만 사용'을 지키기 위해서 함수 추가
+    func getReceiverName() -> String {
+        receiverInfo.getName()
+    }
+    
+    func getReceiverAddress() -> String {
+        receiverInfo.getAddress()
+    }
+    
+    func getReceiverMobile() -> String {
+        receiverInfo.getMobile()
+    }
+    
+    func getDiscountedCost() -> Int {
+        discountedCost.getDiscountedCost()
     }
     
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
@@ -84,28 +84,36 @@ struct DeliveryCost {
 
 
 // MARK: - Parcel Information
-struct ReceiverInfo {
+struct Address {
     private let address: String
-    private let receiverName: String
-    private let receiverMobile: String
     
-    init(address: String, receiverName: String, receiverMobile: String) {
+    init(_ address: String) {
         self.address = address
-        self.receiverName = receiverName
-        self.receiverMobile = receiverMobile
-    }
-    
-    func getName() -> String{
-        return receiverName
-    }
-    
-    func getMobile() -> String {
-        return receiverMobile
     }
     
     func getAddress() -> String {
         return address
     }
+}
+
+
+struct ReceiverInfo {
+    private let name: String
+    private let mobile: String
+    
+    init(name: String, mobile: String) {
+        self.name = name
+        self.mobile = mobile
+    }
+    
+    func getName() -> String{
+        return name
+    }
+    
+    func getMobile() -> String {
+        return mobile
+    }
+    
 }
 
 // 원칙 2 'else 사용 금지'에서 볼 수 있듯이 여기에서는 전략 패턴을 사용했습니다. DiscountedCost와 ParcelInformation를 변경하지 않고도 쉽게 할인 유형을 확장할 수 있다는 장점이 있습니다. 테스트로 "HolidayDiscount"라는 새로운 유형의 할인 정책을 추가했습니다. 디스카운트 전략(DiscountStrategy) 프로토콜을 준수하는 새로운 HolidayDiscount 구조체를 생성했고, Discount 열거형에 새로운 'holiday' 케이스를 추가했고, 마지막으로 ParcelOrderView의 currentDiscountStrategies 배열에 새로운 전략을 추가하는 것만으로만 충분했습니다. 여기서 OCP를 따르는 것의 장점을 느꼈습니다.
@@ -133,10 +141,12 @@ struct DiscountedCost {
 
 
 struct ParcelInformation {
+    private let address: Address
     private let receiverInfo: ReceiverInfo
     private let discountedCost: DiscountedCost
     
-    init(receiverInfo: ReceiverInfo, discountedCost: DiscountedCost) {
+    init(address: Address, receiverInfo: ReceiverInfo, discountedCost: DiscountedCost) {
+        self.address = address
         self.receiverInfo = receiverInfo
         self.discountedCost = discountedCost
     }
@@ -147,7 +157,7 @@ struct ParcelInformation {
     }
     
     func getReceiverAddress() -> String {
-        receiverInfo.getAddress()
+        address.getAddress()
     }
     
     func getReceiverMobile() -> String {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelInformation.swift
@@ -7,83 +7,7 @@
 
 import Foundation
 
-// MARK: - Discount Strategies
 
-enum Discount: Int {
-    case none = 0, vip, coupon, holiday
-    
-    var rate: Double {
-           switch self {
-           case .none:
-               return 1 // no discount
-           case .vip:
-               return 0.8  // 20% discount
-           case .coupon:
-               return 0.5  // 50% discount
-           case .holiday:
-               return 0.85  // 15% discount
-           }
-       }
-}
-
-protocol DiscountStrategy {
-    func applyDiscount(deliveryCost: DeliveryCost, discountRate: Double) -> Int
-    func canAccept(discount: Discount) -> Bool
-}
-
-extension DiscountStrategy {
-    func applyDiscount(deliveryCost: DeliveryCost, discountRate: Double) -> Int {
-        Int(deliveryCost.cost * discountRate)
-    }
-}
-
-struct NoDiscount: DiscountStrategy {
-    func canAccept(discount: Discount) -> Bool {
-        return discount == .none
-    }
-}
-
-struct VIPDiscount: DiscountStrategy {
-    func canAccept(discount: Discount) -> Bool {
-        return discount == .vip
-    }
-}
-
-struct CouponDiscount: DiscountStrategy {
-    func canAccept(discount: Discount) -> Bool {
-        return discount == .coupon
-    }
-}
-
-// 이 새로운 전략은 테스트로 추가되었습니다.
-struct HolidayDiscount: DiscountStrategy {
-    func canAccept(discount: Discount) -> Bool {
-        return discount == .holiday
-    }
-}
-
-
-// MARK: - Delivery Cost
-
-// cost가 음수 또는 0이 아닌지 확인하기 위해 init()에서 배송 비용을 검증합니다.
-struct DeliveryCost {
-    private(set) var cost: Double
-    
-    private static func validate(_ cost: Double) -> Bool {
-        return cost >= 0
-    }
-    
-    init?(_ cost: Double) {
-        guard Self.validate(cost) else {
-            print("Invalid cost: Cost must be greater than or equal to 0.")
-            return nil
-        }
-        self.cost = cost
-    }
-}
-
-
-// MARK: - Parcel Information
 struct Address {
     private(set) var address: String
     
@@ -102,6 +26,25 @@ struct Receiver {
         self.mobile = mobile
     }
 }
+
+
+// cost가 음수 아닌지 확인하기 위해 init()에서 배송 비용을 검증합니다.
+struct DeliveryCost {
+    private(set) var cost: Double
+    
+    private static func validate(_ cost: Double) -> Bool {
+        return cost >= 0
+    }
+    
+    init?(_ cost: Double) {
+        guard Self.validate(cost) else {
+            print("Invalid cost: Cost must be greater than or equal to 0.")
+            return nil
+        }
+        self.cost = cost
+    }
+}
+
 
 // 원칙 2 'else 사용 금지'에서 볼 수 있듯이 여기에서는 전략 패턴을 사용했습니다. DiscountedCost와 ParcelInformation를 변경하지 않고도 쉽게 할인 유형을 확장할 수 있다는 장점이 있습니다. 테스트로 "HolidayDiscount"라는 새로운 유형의 할인 정책을 추가했습니다. 디스카운트 전략(DiscountStrategy) 프로토콜을 준수하는 새로운 HolidayDiscount 구조체를 생성했고, Discount 열거형에 새로운 'holiday' 케이스를 추가했고, 마지막으로 ParcelOrderView의 currentDiscountStrategies 배열에 새로운 전략을 추가하는 것만으로만 충분했습니다. 여기서 OCP를 따르는 것의 장점을 느꼈습니다.
 struct DiscountCostCalculator {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -78,10 +78,10 @@ class ParcelOrderView: UIView {
         else {
             return
         }
-        let receiverInfo = ReceiverInfo(address: address, receiverName: name, receiverMobile: mobile)
+        let receiverInfo = ReceiverInfo(name: name, mobile: mobile)
         let discountedCost = DiscountedCost(deliveryCost: deliveryCost, discount: discount, discountStrategies: currentDiscountStrategies)
         
-        let parcelInformation: ParcelInformation = .init(receiverInfo: receiverInfo, discountedCost: discountedCost)
+        let parcelInformation: ParcelInformation = .init(address: Address(address), receiverInfo: receiverInfo, discountedCost: discountedCost)
         delegate.parcelOrderMade(parcelInformation)
     }
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -79,9 +79,9 @@ class ParcelOrderView: UIView {
             return
         }
         let receiverInfo = Receiver(name: name, mobile: mobile)
-        let discountedCost = DiscountedCost(deliveryCost: deliveryCost, discount: discount, discountStrategies: currentDiscountStrategies)
+        let discountCostCalculator = DiscountCostCalculator(deliveryCost: deliveryCost, discount: discount, discountStrategies: currentDiscountStrategies)
         
-        let parcelInformation: ParcelInformation = .init(address: Address(address), receiverInfo: receiverInfo, discountedCost: discountedCost)
+        let parcelInformation: ParcelInformation = .init(address: Address(address), receiverInfo: receiverInfo, discountCostCalculator: discountCostCalculator)
         delegate.parcelOrderMade(parcelInformation)
     }
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -13,6 +13,7 @@ protocol ParcelOrderViewDelegate {
 class ParcelOrderView: UIView {
     
     private var delegate: ParcelOrderViewDelegate!
+    private let currentDiscountStrategies: [DiscountStrategy] = [NoDiscount(), VIPDiscount(), CouponDiscount(), HolidayDiscount()]
     
     private let receiverNameField: UITextField = {
         let field: UITextField = .init()
@@ -45,6 +46,7 @@ class ParcelOrderView: UIView {
         control.insertSegment(withTitle: "없음", at: 0, animated: false)
         control.insertSegment(withTitle: "VIP", at: 1, animated: false)
         control.insertSegment(withTitle: "쿠폰", at: 2, animated: false)
+        control.insertSegment(withTitle: "명절", at: 3, animated: false)
         control.selectedSegmentIndex = 0
         return control
     }()
@@ -70,17 +72,16 @@ class ParcelOrderView: UIView {
               mobile.isEmpty == false,
               address.isEmpty == false,
               costString.isEmpty == false,
-              let cost: Int = Int(costString),
+              let cost: Double = Double(costString),
               let deliveryCost: DeliveryCost = try? .init(cost),
               let discount: Discount = Discount(rawValue: discountSegmented.selectedSegmentIndex)
         else {
             return
         }
-        let parcelInformation: ParcelInformation = .init(receiverInfo: ReceiverInfo(address: address, 
-                                                                                    receiverName: name,
-                                                                                    receiverMobile: mobile),
-                                                         deliveryCost: deliveryCost,
-                                                         discount: discount)
+        let receiverInfo = ReceiverInfo(address: address, receiverName: name, receiverMobile: mobile)
+        let discountedCost = DiscountedCost(deliveryCost: deliveryCost, discount: discount, discountStrategies: currentDiscountStrategies)
+        
+        let parcelInformation: ParcelInformation = .init(receiverInfo: receiverInfo, discountedCost: discountedCost)
         delegate.parcelOrderMade(parcelInformation)
     }
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -13,6 +13,7 @@ protocol ParcelOrderViewDelegate {
 class ParcelOrderView: UIView {
     
     private var delegate: ParcelOrderViewDelegate!
+    
     private let currentDiscountStrategies: [DiscountStrategy] = [NoDiscount(), VIPDiscount(), CouponDiscount(), HolidayDiscount()]
     
     private let receiverNameField: UITextField = {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -73,12 +73,12 @@ class ParcelOrderView: UIView {
               address.isEmpty == false,
               costString.isEmpty == false,
               let cost: Double = Double(costString),
-              let deliveryCost: DeliveryCost = try? .init(cost),
+              let deliveryCost: DeliveryCost = .init(cost),
               let discount: Discount = Discount(rawValue: discountSegmented.selectedSegmentIndex)
         else {
             return
         }
-        let receiverInfo = ReceiverInfo(name: name, mobile: mobile)
+        let receiverInfo = Receiver(name: name, mobile: mobile)
         let discountedCost = DiscountedCost(deliveryCost: deliveryCost, discount: discount, discountStrategies: currentDiscountStrategies)
         
         let parcelInformation: ParcelInformation = .init(address: Address(address), receiverInfo: receiverInfo, discountedCost: discountedCost)

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
+class ParcelOrderViewController: UIViewController {
     
     // 원래 갖고 있는 ParcelOrderProcessor 타입 의존성을 없애기 위해서 추상화 주입
     private let parcelProcessor: ParcelOrderProcessorProtocol
@@ -24,13 +24,18 @@ class ParcelOrderViewController: UIViewController, ParcelOrderViewDelegate {
     override func loadView() {
         view = ParcelOrderView(delegate: self)
     }
+
+}
+
+
+extension ParcelOrderViewController: ParcelOrderViewDelegate {
     
     func parcelOrderMade(_ parcelInformation: ParcelInformation) {
+        
         parcelProcessor.process(parcelInformation: parcelInformation) { (parcelInformation) in
             let invoiceViewController: InvoiceViewController = .init(parcelInformation: parcelInformation)
             navigationController?.pushViewController(invoiceViewController, animated: true)
         }
     }
-
 }
 

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 
-// DatabaseParcelInformationPersistence와 ParcelOrderProcessor를 위한 파일을 따로 따로 만들어서 분리해야 할까요?
 
 protocol ParcelInformationPersistence {
     func save(parcelInformation: ParcelInformation)

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/SceneDelegate.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/SceneDelegate.swift
@@ -14,9 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let scene: UIWindowScene = (scene as? UIWindowScene) else { return }
         
-        let viewController: ParcelOrderViewController = ParcelOrderViewController(parcelProcessor:
-                                                                                    ParcelOrderProcessor(parcelInformationPersistence:
-                                                                                                            DatabaseParcelInformationPersistence()))
+        let viewController: ParcelOrderViewController = ParcelOrderViewController(parcelProcessor: ParcelOrderProcessor(parcelInformationPersistence: DatabaseParcelInformationPersistence()))
         let navigationController: UINavigationController = UINavigationController(rootViewController: viewController)
         navigationController.navigationBar.prefersLargeTitles = true
         navigationController.navigationBar.tintColor = .black


### PR DESCRIPTION
@ryan-son 안녕하세요!
STEP1 관련 수정사항과 STEP 2 PR을 보냅니다.

## STEP1 수정사항

- `ReceiverInfo` 타입 분리: `Address` 타입을 따로 생선하여, `Receiver` 타입이 name과 mobile만 가지고 있도록 수정;
- `DeliveryCost`에 FailableInit 적용
- 데이터를 표현하는 타입에 (`ParcelInformation, Address, Receiver`) 있었던 `getName(), getMobile()`등 함수를 없앴습니다. 단, `ParcelInformation`에 있는 `getDiscountedCost()`는 (`DiscountCostCalculator`가 기능을 제공하는 타입이기 때문에) 그대로 남겼습니다.

## STEP2
###OCP의 실현
전략 패턴을 사용하여 `DiscountStrategy` 프로토콜을 만들었습니다. 그리고 `NoDiscount`, `VIPDiscount`, `CouponDiscount`라는 DiscountStrategy를 따르는 타입들을 생성했습니다. STEP1 제안하신 대로 `rate` 프로퍼티를 추가하여 `Discount` 열거형을 확장했습니다.
기존 `DiscountedCost`를 `DiscountCostCalculator`로 변경하여 할인 금액을 계산하는 책임을 할당했습니다.

### 고민했던 점
전체적으로 OCP를 적용할때 프로토콜을 사용하는 것의 장단점에 대해 고민했습니다.  그리고 지금 제가 작성한 코드의 개선사항들을 알려주시면 감사합니다.

