### PR TITLE
택배송장앱 [STEP 2] Khan1201

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -87,7 +87,7 @@ class ParcelOrderView: UIView {
                 ),
                 cost: try .init(
                     delivery: cost,
-                    discountStrategies: [NoDiscount(), VIPDiscount(), CouponDiscount()],
+                    discountStrategies: Discount.strategies,
                     discountCategory: discount
                 )
             )

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -76,20 +76,26 @@ class ParcelOrderView: UIView {
             return
         }
         
-        let parcelInformation: ParcelInformation = .init(
-            user: .init(
-                address: address,
-                receiver: .init(
-                    name: name,
-                    mobile: mobile
+        do {
+            let parcelInformation: ParcelInformation = .init(
+                user: .init(
+                    address: address,
+                    receiver: .init(
+                        name: name,
+                        mobile: mobile
+                    )
+                ),
+                cost: try .init(
+                    delivery: cost,
+                    discountStrategies: [NoDiscount(), VIPDiscount(), CouponDiscount()],
+                    discountCategory: discount
                 )
-            ),
-            cost: .init(
-                delivery: cost,
-                discountCategory: discount
             )
-        )
-        delegate.parcelOrderMade(parcelInformation)
+            delegate.parcelOrderMade(parcelInformation)
+            
+        } catch {
+            print("discount에 해당되는 DiscountStrategy가 존재하지 않습니다.")
+        }
     }
     
     private func layoutView() {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -225,6 +225,8 @@ protocol DiscountStrategy {
 
 enum Discount: Int {
     case none = 0, vip, coupon
+    
+    static let strategies: [DiscountStrategy] = [NoDiscount(), VIPDiscount(), CouponDiscount()]
 }
 
 enum DiscountAmount {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -160,7 +160,7 @@ enum Discount: Int {
 //    }
 //}
 
-// MARK: - 수정 후 코드
+// MARK: - 수정 후 코드 (step 1)
 
 class ParcelOrderProcessor: ParcelOrderPersistable {
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -77,6 +77,72 @@ import Foundation
 
 // MARK: - 수정 후 코드 (step 2)
 
+//final class ParcelInformation {
+//    struct User {
+//        let address: String
+//        let receiver: Receiver
+//    }
+//
+//    struct Receiver {
+//        let name: String
+//        let mobile: String
+//    }
+//    
+//    struct Cost {
+//        let delivery: Int
+//        let discountCategory: Discount
+//        var discountedDelivery: Int {
+//            return discountCategory.strategy.applyDiscount(deliveryCost: delivery)
+//        }
+//    }
+//    
+//    let user: User
+//    let cost: Cost
+//
+//    init(user: User, cost: Cost) {
+//        self.user = user
+//        self.cost = cost
+//    }
+//}
+//
+//struct NoDiscount: DiscountStrategy {
+//    func applyDiscount(deliveryCost: Int) -> Int {
+//        return deliveryCost
+//    }
+//}
+//
+//struct VIPDiscount: DiscountStrategy {
+//    func applyDiscount(deliveryCost: Int) -> Int {
+//        return deliveryCost / 20
+//    }
+//}
+//
+//struct CouponDiscount: DiscountStrategy {
+//    func applyDiscount(deliveryCost: Int) -> Int {
+//        return deliveryCost / 2
+//    }
+//}
+//
+//protocol DiscountStrategy {
+//    func applyDiscount(deliveryCost: Int) -> Int
+//}
+//
+//enum Discount: Int {
+//    case none = 0, vip, coupon
+//    var strategy: DiscountStrategy {
+//        switch self {
+//        case .none:
+//            return NoDiscount()
+//        case .vip:
+//            return VIPDiscount()
+//        case .coupon:
+//            return CouponDiscount()
+//        }
+//    }
+//}
+
+// MARK: - 수정 후 코드 (step 2 보완 (swtich 제거, 매직넘버 제거))
+
 final class ParcelInformation {
     struct User {
         let address: String
@@ -90,9 +156,19 @@ final class ParcelInformation {
     
     struct Cost {
         let delivery: Int
+        let discountStrategies: [DiscountStrategy]
         let discountCategory: Discount
         var discountedDelivery: Int {
-            return discountCategory.strategy.applyDiscount(deliveryCost: delivery)
+            return discountStrategies.filter { $0.canDiscount(category: discountCategory) }.first?.applyDiscount(deliveryCost: delivery) ?? 0
+        }
+        
+        init(delivery: Int, discountStrategies: [DiscountStrategy], discountCategory: Discount) throws {
+            self.delivery = delivery
+            
+            guard discountStrategies.contains(where: {$0.discountCategory == discountCategory}) else { throw NSError() as Error }
+            self.discountStrategies = discountStrategies
+            
+            self.discountCategory = discountCategory
         }
     }
     
@@ -106,39 +182,54 @@ final class ParcelInformation {
 }
 
 struct NoDiscount: DiscountStrategy {
+    let discountCategory: Discount = .none
+    
     func applyDiscount(deliveryCost: Int) -> Int {
         return deliveryCost
+    }
+    
+    func canDiscount(category: Discount) -> Bool {
+        return category == .none
     }
 }
 
 struct VIPDiscount: DiscountStrategy {
+    let discountCategory: Discount = .vip
+    
     func applyDiscount(deliveryCost: Int) -> Int {
-        return deliveryCost / 20
+        return deliveryCost / DiscountAmount.vip
+    }
+    
+    func canDiscount(category: Discount) -> Bool {
+        return category == .vip
     }
 }
 
 struct CouponDiscount: DiscountStrategy {
+    let discountCategory: Discount = .coupon
+    
     func applyDiscount(deliveryCost: Int) -> Int {
-        return deliveryCost / 2
+        return deliveryCost / DiscountAmount.coupon
+    }
+    
+    func canDiscount(category: Discount) -> Bool {
+        return category == .coupon
     }
 }
 
 protocol DiscountStrategy {
+    var discountCategory: Discount { get }
     func applyDiscount(deliveryCost: Int) -> Int
+    func canDiscount(category: Discount) -> Bool
 }
 
 enum Discount: Int {
     case none = 0, vip, coupon
-    var strategy: DiscountStrategy {
-        switch self {
-        case .none:
-            return NoDiscount()
-        case .vip:
-            return VIPDiscount()
-        case .coupon:
-            return CouponDiscount()
-        }
-    }
+}
+
+enum DiscountAmount {
+    static let vip: Int = 20
+    static let coupon: Int = 2
 }
 
 // MARK: - 수정 전 코드

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -34,7 +34,48 @@ import Foundation
 //    }
 //}
 
-// MARK: - 수정 후 코드
+// MARK: - 수정 후 코드 (step 1)
+
+//final class ParcelInformation {
+//    struct User {
+//        let address: String
+//        let receiver: Receiver
+//    }
+//
+//    struct Receiver {
+//        let name: String
+//        let mobile: String
+//    }
+//    
+//    struct Cost {
+//        let delivery: Int
+//        let discountCategory: Discount
+//        var discountedDelivery: Int {
+//            switch discountCategory {
+//            case .none:
+//                return delivery
+//            case .vip:
+//                return delivery / 5 * 4
+//            case .coupon:
+//                return delivery / 2
+//            }
+//        }
+//    }
+//    
+//    let user: User
+//    let cost: Cost
+//
+//    init(user: User, cost: Cost) {
+//        self.user = user
+//        self.cost = cost
+//    }
+//}
+//
+//enum Discount: Int {
+//    case none = 0, vip, coupon
+//}
+
+// MARK: - 수정 후 코드 (step 2)
 
 final class ParcelInformation {
     struct User {
@@ -51,14 +92,7 @@ final class ParcelInformation {
         let delivery: Int
         let discountCategory: Discount
         var discountedDelivery: Int {
-            switch discountCategory {
-            case .none:
-                return delivery
-            case .vip:
-                return delivery / 5 * 4
-            case .coupon:
-                return delivery / 2
-            }
+            return discountCategory.strategy.applyDiscount(deliveryCost: delivery)
         }
     }
     
@@ -71,8 +105,40 @@ final class ParcelInformation {
     }
 }
 
+struct NoDiscount: DiscountStrategy {
+    func applyDiscount(deliveryCost: Int) -> Int {
+        return deliveryCost
+    }
+}
+
+struct VIPDiscount: DiscountStrategy {
+    func applyDiscount(deliveryCost: Int) -> Int {
+        return deliveryCost / 20
+    }
+}
+
+struct CouponDiscount: DiscountStrategy {
+    func applyDiscount(deliveryCost: Int) -> Int {
+        return deliveryCost / 2
+    }
+}
+
+protocol DiscountStrategy {
+    func applyDiscount(deliveryCost: Int) -> Int
+}
+
 enum Discount: Int {
     case none = 0, vip, coupon
+    var strategy: DiscountStrategy {
+        switch self {
+        case .none:
+            return NoDiscount()
+        case .vip:
+            return VIPDiscount()
+        case .coupon:
+            return CouponDiscount()
+        }
+    }
 }
 
 // MARK: - 수정 전 코드

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -189,7 +189,7 @@ struct NoDiscount: DiscountStrategy {
     }
     
     func canDiscount(category: Discount) -> Bool {
-        return category == .none
+        return category == discountCategory
     }
 }
 
@@ -201,7 +201,7 @@ struct VIPDiscount: DiscountStrategy {
     }
     
     func canDiscount(category: Discount) -> Bool {
-        return category == .vip
+        return category == discountCategory
     }
 }
 
@@ -213,7 +213,7 @@ struct CouponDiscount: DiscountStrategy {
     }
     
     func canDiscount(category: Discount) -> Bool {
-        return category == .coupon
+        return category == discountCategory
     }
 }
 


### PR DESCRIPTION
@YebinKim 
안녕하세요 븨븨 !!
1주차 내용을 이해하고 정리하느라 시간이 너무 오래 걸렸습니다 ..
늦게 PR 요청해서 너무 죄송합니다 .. 😂
<br>

## 고민했던 점
### OCP,  객체 미용 체조 2원칙 적용
주석으로 step2 요구사항 만족 코드, step2 요구사항 만족 코드를 보완한 코드로 구분하여 작성하였습니다 !

OCP(Open Close Principle) - 개방 폐쇄 원칙은 확장에는 열려있고 변경에는 닫혀있어야 합니다. 확장은 클래스의 행동의 변화 없이 가능해야 합니다. 기존 할인된 배송 가격 연산 프로퍼티에서 Discount 종류가 추가된다면 수정이 발생하므로 OCP에 위배됩니다. DiscountStrategy 프로토콜을 정의하여 연산 프로퍼티의 Discount에 따른 동작들을 추상화합니다. Discount case별로 새로운 타입을 생성 후 DiscountStrategy 프로토콜을 채택하여 함수를 정의하였습니다. 기존 요구사항에 따라서, Discount enum에 DiscountStrategy 타입의 연산 프로퍼티를 생성 후 할인된 배송 가격 연산 프로퍼티를 DiscountStrategy 타입의 함수로 접근하도록 수정하였습니다.

이렇게 추상화를 진행하여 확장에 효율적인 코드를 작성하였지만, 여전히 switch를 사용하고 있으므로 새로운 할인 종류가 생기면 Discount의 DiscountStrategy 타입의 연산 프로퍼티의 수정이 발생합니다. switch 문을 제거하고자, DiscountStrategy 프로토콜에 Discount 타입을 가지는 변수 discountCategory, 할인 적용 가능한지 Bool을 리턴하는 함수 canDiscount(category:)를 추가하였습니다. 그 후 Cost 구조체에 [DiscountStrategy] 타입의 discountStrategies을 추가하여 Discount에 해당되는 DiscountStrategy로 필터링 후 적용하였습니다 !
<br>

## 조언을 얻고 싶은 부분
### OCP,  객체 미용 체조 2원칙 적용
- 기존 요구사항 코드에서 switch문을 제거하고 싶다는 생각이 들었습니다. 제가 수정한 코드가 잘 제거가 되었는지 비비님의 의견이 궁금합니다 ! 
그리고 비비님은 switch문을 약간의 타협으로 사용을 하시는지, 아니면 아예 사용을 안하시는지 궁금합니다! 🤔
- OCP의 '확장에는 열려있고, 수정에는 닫혀있다' 라는 의미에서 '수정에는 닫혀있다'라는 부분이 아직 알쏭달쏭합니다. 어떤 enum의 case가 추가되면 기존의 해당 enum을 사용하는 코드에선 수정이 일어나면 안된다라는 말인가요? 🤔