### PR TITLE
택배 송장 제조기 [STEP Bonus] Choiy

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7D34DE142B63A8FF00A7EC6B /* ParcelReciptSendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D34DE132B63A8FF00A7EC6B /* ParcelReciptSendable.swift */; };
+		7D34DE162B63A97C00A7EC6B /* SendMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D34DE152B63A97C00A7EC6B /* SendMethod.swift */; };
 		7DCE0C022B6128EB00EAA5CD /* ReceiverInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */; };
 		7DCE0C042B61298A00EAA5CD /* CostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C032B61298A00EAA5CD /* CostInformation.swift */; };
 		7DCE0C062B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCE0C052B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift */; };
@@ -23,6 +25,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7D34DE132B63A8FF00A7EC6B /* ParcelReciptSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelReciptSendable.swift; sourceTree = "<group>"; };
+		7D34DE152B63A97C00A7EC6B /* SendMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendMethod.swift; sourceTree = "<group>"; };
 		7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiverInformation.swift; sourceTree = "<group>"; };
 		7DCE0C032B61298A00EAA5CD /* CostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostInformation.swift; sourceTree = "<group>"; };
 		7DCE0C052B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseParcelInformationPersistence.swift; sourceTree = "<group>"; };
@@ -78,9 +82,11 @@
 				C741F5132B468AC300A4DDC0 /* InvoiceView.swift */,
 				C741F50D2B46659500A4DDC0 /* ParcelProcessor.swift */,
 				7DCE0C052B612F3400EAA5CD /* DatabaseParcelInformationPersistence.swift */,
+				7D34DE132B63A8FF00A7EC6B /* ParcelReciptSendable.swift */,
 				7DCE0C012B6128EB00EAA5CD /* ReceiverInformation.swift */,
 				7DCE0C032B61298A00EAA5CD /* CostInformation.swift */,
 				7DF00A912B62819900DC6DB7 /* Discount.swift */,
+				7D34DE152B63A97C00A7EC6B /* SendMethod.swift */,
 				C741F5022B46658400A4DDC0 /* Assets.xcassets */,
 				C741F5042B46658400A4DDC0 /* LaunchScreen.storyboard */,
 				C741F5072B46658400A4DDC0 /* Info.plist */,
@@ -158,7 +164,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D34DE162B63A97C00A7EC6B /* SendMethod.swift in Sources */,
 				7DCE0C042B61298A00EAA5CD /* CostInformation.swift in Sources */,
+				7D34DE142B63A8FF00A7EC6B /* ParcelReciptSendable.swift in Sources */,
 				7DF00A922B62819900DC6DB7 /* Discount.swift in Sources */,
 				C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */,
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/CostInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/CostInformation.swift
@@ -14,7 +14,7 @@ struct CostInformation {
     init(deliveryCost: Int, discount: Discount) {
         self.deliveryCost = deliveryCost
         
-        let strategies: [DiscountStrategy] = [NoDiscount(), VipDiscount(), CouponDiscount()]
+        let strategies: [DiscountStrategy] = [NoDiscount(), VipDiscount(), CouponDiscount(), NewcomerDiscount()]
         strategy = strategies.first { $0.canApply(discount) }
     }
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/CostInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/CostInformation.swift
@@ -9,15 +9,16 @@ import Foundation
 
 struct CostInformation {
     let deliveryCost: Int
-    private let discount: Discount
-    
-    var discountedCost: Int {
-        let discountStrategy: DiscountStrategy = discount.strategy
-        return discountStrategy.discountedCost(self.deliveryCost)
-    }
+    private var strategy: DiscountStrategy?
     
     init(deliveryCost: Int, discount: Discount) {
         self.deliveryCost = deliveryCost
-        self.discount = discount
+        
+        let strategies: [DiscountStrategy] = [NoDiscount(), VipDiscount(), CouponDiscount()]
+        strategy = strategies.first { $0.canApply(discount) }
+    }
+    
+    func discountedCost() -> Int? {
+        return strategy?.discountedCost(deliveryCost)
     }
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
@@ -42,6 +42,16 @@ struct CouponDiscount: DiscountStrategy {
     }
 }
 
+struct NewcomerDiscount: DiscountStrategy {
+    func discountedCost(_ deliveryCost: Int) -> Int {
+        return deliveryCost / 10 * 9
+    }
+    
+    func canApply(_ discount: Discount) -> Bool {
+        return discount == .newcomer
+    }
+}
+
 enum Discount: Int {
-    case none = 0, vip, coupon
+    case none = 0, vip, coupon, newcomer
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Discount.swift
@@ -9,11 +9,16 @@ import Foundation
 
 protocol DiscountStrategy {
     func discountedCost(_ deliveryCost: Int) -> Int
+    func canApply(_ discount: Discount) -> Bool
 }
 
 struct NoDiscount: DiscountStrategy {
     func discountedCost(_ deliveryCost: Int) -> Int {
         return deliveryCost
+    }
+    
+    func canApply(_ discount: Discount) -> Bool {
+        return discount == .none
     }
 }
 
@@ -21,24 +26,22 @@ struct VipDiscount: DiscountStrategy {
     func discountedCost(_ deliveryCost: Int) -> Int {
         return deliveryCost / 5 * 4
     }
+    
+    func canApply(_ discount: Discount) -> Bool {
+        return discount == .vip
+    }
 }
 
 struct CouponDiscount: DiscountStrategy {
     func discountedCost(_ deliveryCost: Int) -> Int {
         return deliveryCost / 2
     }
+    
+    func canApply(_ discount: Discount) -> Bool {
+        return discount == .coupon
+    }
 }
 
 enum Discount: Int {
     case none = 0, vip, coupon
-    var strategy: DiscountStrategy {
-        switch self {
-        case .none:
-            return NoDiscount()
-        case .vip:
-            return VipDiscount()
-        case .coupon:
-            return CouponDiscount()
-        }
-    }
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/InvoiceView.swift
@@ -21,25 +21,34 @@ class InvoiceView: UIView {
     }
     
     private func layoutView() {
+        
+        let reciverInformation: ReceiverInformation = parcelInformation.reciverInformation
+        
         let nameLabel: UILabel = UILabel()
         nameLabel.textColor = .black
         nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        nameLabel.text = "이름 : \(parcelInformation.reciverInformation.name)"
+        nameLabel.text = "이름 : \(reciverInformation.name)"
         
         let mobileLabel: UILabel = UILabel()
         mobileLabel.textColor = .black
         mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        mobileLabel.text = "전화 : \(parcelInformation.reciverInformation.mobile)"
+        mobileLabel.text = "전화 : \(reciverInformation.mobile)"
         
         let addressLabel: UILabel = UILabel()
         addressLabel.textColor = .black
         addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        addressLabel.text = "주소 : \(parcelInformation.reciverInformation.address)"
+        addressLabel.text = "주소 : \(reciverInformation.address)"
+        
+        let costInformation: CostInformation = parcelInformation.costInformation
+        var discountedCostInfoString: String = "unknown"
+        if let discountedCost = costInformation.discountedCost() {
+            discountedCostInfoString = "\(discountedCost)"
+        }
         
         let costLabel: UILabel = UILabel()
         costLabel.textColor = .black
         costLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        costLabel.text = "요금 : \(parcelInformation.costInformation.discountedCost)"
+        costLabel.text = "요금 : \(discountedCostInfoString)"
                 
         let mainStackView: UIStackView = .init(arrangedSubviews: [nameLabel, mobileLabel, addressLabel, costLabel])
         mainStackView.axis = .vertical

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -50,6 +50,15 @@ class ParcelOrderView: UIView {
         return control
     }()
     
+    private let sendMethodSegmented: UISegmentedControl = {
+        let control: UISegmentedControl = .init()
+        control.insertSegment(withTitle: "없음", at: 0, animated: false)
+        control.insertSegment(withTitle: "이메일", at: 1, animated: false)
+        control.insertSegment(withTitle: "문자", at: 2, animated: false)
+        control.selectedSegmentIndex = 0
+        return control
+    }()
+    
     init(delegate: ParcelOrderViewDelegate) {
         self.delegate = delegate
         super.init(frame: .zero)
@@ -72,7 +81,8 @@ class ParcelOrderView: UIView {
               address.isEmpty == false,
               costString.isEmpty == false,
               let cost: Int = Int(costString),
-              let discount: Discount = Discount(rawValue: discountSegmented.selectedSegmentIndex)
+              let discount: Discount = Discount(rawValue: discountSegmented.selectedSegmentIndex),
+              let sendMethod: SendMethod = SendMethod(rawValue: sendMethodSegmented.selectedSegmentIndex)
         else {
             return
         }
@@ -81,7 +91,8 @@ class ParcelOrderView: UIView {
                                                          receiverName: name,
                                                          receiverMobile: mobile,
                                                          deliveryCost: cost,
-                                                         discount: discount)
+                                                         discount: discount,
+                                                         sendMethod: sendMethod)
         delegate.parcelOrderMade(parcelInformation)
     }
     
@@ -146,7 +157,7 @@ class ParcelOrderView: UIView {
         makeOrderButton.setTitle("택배 보내기", for: .normal)
         makeOrderButton.addTarget(self, action: #selector(touchUpOrderButton), for: .touchUpInside)
         
-        let mainStackView: UIStackView = .init(arrangedSubviews: [logoImageView, nameStackView, mobileStackView, addressStackView, costStackView, discountStackView, makeOrderButton])
+        let mainStackView: UIStackView = .init(arrangedSubviews: [logoImageView, nameStackView, mobileStackView, addressStackView, costStackView, discountStackView, sendMethodSegmented, makeOrderButton])
         mainStackView.axis = .vertical
         mainStackView.distribution = .fillEqually
         mainStackView.spacing = 8

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelOrderView.swift
@@ -45,6 +45,7 @@ class ParcelOrderView: UIView {
         control.insertSegment(withTitle: "없음", at: 0, animated: false)
         control.insertSegment(withTitle: "VIP", at: 1, animated: false)
         control.insertSegment(withTitle: "쿠폰", at: 2, animated: false)
+        control.insertSegment(withTitle: "신규", at: 3, animated: false)
         control.selectedSegmentIndex = 0
         return control
     }()

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelProcessor.swift
@@ -9,10 +9,16 @@ import Foundation
 class ParcelInformation {
     let reciverInformation: ReceiverInformation
     let costInformation: CostInformation
+    let reciptSendMethod: SendMethod
 
-    init(address: String, receiverName: String, receiverMobile: String, deliveryCost: Int, discount: Discount) {
+    init(
+        address: String, receiverName: String, receiverMobile: String,
+        deliveryCost: Int, discount: Discount,
+        sendMethod: SendMethod
+    ) {
         self.reciverInformation = ReceiverInformation(address: address, name: receiverName, mobile: receiverMobile)
         self.costInformation = CostInformation(deliveryCost: deliveryCost, discount: discount)
+        self.reciptSendMethod = sendMethod
     }
 }
 
@@ -34,6 +40,9 @@ class ParcelOrderProcessor: OrderProcessor {
         // 데이터베이스에 주문 저장
         databasePersistence.save(parcelInformation: parcelInformation)
         
+        // 영수증 전송
+        let reciptSender: ReciptReciptSender = ReciptReciptSender(method: parcelInformation.reciptSendMethod)
+        reciptSender.send(costInformation: parcelInformation.costInformation)
         onComplete(parcelInformation)
     }
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelReciptSendable.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/ParcelReciptSendable.swift
@@ -1,0 +1,27 @@
+//
+//  ParcelReciptSendable.swift
+//  ParcelInvoiceMaker
+//
+//  Created by Daegeon Choi on 2024/01/26.
+//
+
+import Foundation
+
+protocol ParcelReciptSendable {
+    func send(costInformation: CostInformation)
+}
+
+class ReciptReciptSender: ParcelReciptSendable {
+    
+    private var strategy: SendStrategy?
+    
+    init(method: SendMethod) {
+        let strategies: [SendStrategy] = [NoSend(), EmailSend(), SmsSend()]
+        strategy = strategies.first { $0.canUseMethod(method) }
+    }
+    
+    func send(costInformation: CostInformation) {
+        guard let discountedCost = costInformation.discountedCost() else { return }
+        self.strategy?.send(deliveryCost: costInformation.deliveryCost, discountedCost: discountedCost)
+    }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/SendMethod.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/SendMethod.swift
@@ -1,0 +1,55 @@
+//
+//  SendMethod.swift
+//  ParcelInvoiceMaker
+//
+//  Created by Daegeon Choi on 2024/01/26.
+//
+
+import Foundation
+
+protocol SendStrategy {
+    func send(deliveryCost: Int, discountedCost: Int)
+    func canUseMethod(_ method: SendMethod) -> Bool
+}
+
+extension SendStrategy {
+    func recipt(_ deliveryCost: Int, _ discountedCost: Int) -> String {
+        return "배송비 \(deliveryCost), 할인가 \(discountedCost)"
+    }
+}
+
+struct NoSend: SendStrategy {
+    func send(deliveryCost: Int, discountedCost: Int) {
+        print("전송 안함")
+    }
+    
+    func canUseMethod(_ method: SendMethod) -> Bool {
+        return method == .none
+    }
+}
+
+struct EmailSend: SendStrategy {
+    func send(deliveryCost: Int, discountedCost: Int) {
+        let recipt: String = recipt(deliveryCost, discountedCost)
+        print("[이메일] \(recipt)")
+    }
+    
+    func canUseMethod(_ method: SendMethod) -> Bool {
+        return method == .email
+    }
+}
+
+struct SmsSend: SendStrategy {
+    func send(deliveryCost: Int, discountedCost: Int) {
+        let recipt: String = recipt(deliveryCost, discountedCost)
+        print("[문자] \(recipt)")
+    }
+    
+    func canUseMethod(_ method: SendMethod) -> Bool {
+        return method == .sms
+    }
+}
+
+enum SendMethod: Int {
+    case none = 0, email, sms
+}


### PR DESCRIPTION
@KYHyeon
안녕하세요! 이번에도 잘부탁드립니다!
STEP 2에서 조언해 주셨던 내용도 같이 수정해 보았습니다!

## 고민했던 점
### SOLID OCP 적용 / 객체 미용 4원칙 적용
- "`CostInformation`이 `DiscountStrategy`를 가지고 있으면 어떨까?" 라는 조언을 주셨었는데,  덕분에 더 새롭고 나은 방법으로 리팩토링이 가능했던 것 같습니다. 
- `Discount`열거형 내부에 `switch`문으로 이루어진 로직을 분리해 보았습니다.
- `CostInformation`이 가진 프로퍼티에 변화가 생기면서 `InvoidView`에서 해당 프로퍼티들에 접근하는 과정에 객체 미용 4원칙 적용을 시도해 보았습니다.

### 영수증 발송 기능 추가
- `ParcelOrderView`에 새로운 `UISegmentedControl`을 추가해 영수증 전송 방식을 선택할 수 있도록 기능을 추가하였습니다.
- `ReciptReciptSender` 클래스가 영수증 전송 메서드를 수행할 수 있도록 하고, 이 메서드를 `ParcelOrderProcessor`의 `Process` 메서드 안에서 실행될 수 있도록 구현하였습니다.

---

## 조언을 얻고 싶은 부분
### SOLID SRP / 객체 미용 2원칙
- `Discount`열거형이 가지고 있던 `DiscountStrategy`를 `CostInformation`이 가지도록 수정하면서 `discountedCost`를 **계산 프로퍼티**에서 **리턴값이 존재하는 함수** 형태로 수정하였습니다.
    - 계산 프로퍼티 이긴 하지만 원시값인 프로퍼티가 두가지 이기도 하고, 특정 로직으로 계산이 이루어져 값을 얻어내는 구조이기 때문에 함수형으로 변경해 보았습니다. 하지만 이런 함수는 `getter` 형식의 함수 인거 같다는 생각이 드는데, 어떤 형식이 좋을지에 대해 조언을 구하고 싶습니다.

### 할인 정책의 추가
```swift
let strategies: [DiscountStrategy] = [NoDiscount(), VipDiscount(), CouponDiscount(), NewcomerDiscount()]
strategy = strategies.first { $0.canApply(discount) 
```

- "신규 고객 할인"이라는 의미로 `Discount` 열거형에 `.newcomer` 케이스를 추가하고, 해당 유형을 위해 `NewcomerDiscount`라는 `DiscountStrategy` 구조체를 만들었습니다.
    - `CostInformation`에서 `DiscountStrategy`를 초기화하는 과정에서 사용 가능한 모든 `DiscountStrategy`를 배열 안에 직접 선언하여 루프를 돌면서 알맞은 구조체를 찾아내는 방식인데, `strategies`의 값들을 직접 넣어주었기 때문에 하드코딩 되었다는 느낌이 드는데, 이러한 방식 때문에 추후에 변경이 힘들어지는 상황이 올 수도 있을까요?

### 영수증 발송 기능 추가

```swift
class ReciptReciptSender: ParcelReciptSendable {
    
    private var strategy: SendStrategy?
    
    init(method: SendMethod) {
        let strategies: [SendStrategy] = [NoSend(), EmailSend(), SmsSend()]
        strategy = strategies.first { $0.canUseMethod(method) }
    }
    
    func send(costInformation: CostInformation) {
        guard let discountedCost = costInformation.discountedCost() else { return }
        self.strategy?.send(deliveryCost: costInformation.deliveryCost, discountedCost: discountedCost)
    }
}

class ParcelOrderProcessor: OrderProcessor { 
    ...
    func process(parcelInformation: ParcelInformation, onComplete: (ParcelInformation) -> Void) {
        
        // 데이터베이스에 주문 저장
        databasePersistence.save(parcelInformation: parcelInformation)
        
        // 영수증 전송
        let reciptSender: ReciptReciptSender = ReciptReciptSender(method: parcelInformation.reciptSendMethod)
        reciptSender.send(costInformation: parcelInformation.costInformation)
        onComplete(parcelInformation)
    }
}

```

- 영수증 발송 기능을 가진 `ReciptReciptSender` 클래스는 init에서 발송 형식을 구분하는 열거형인`SendMethod`를 인자로 받아야 했기 때문에 `ParcelInformationPersistence`와 다르게 `ParcelOrderProcesser`가 프로퍼티로 소유하는 방식이 아니라, `process`메서드의 파라미터인`ParcelInformation`을 사용해 `process` 동작 마다 새로운 클래스를 생성하는 방식으로 구현되었습니다.
    - `SendMethod`를 인자로 받아야 클래스를 만들 수 있기 때문에 사용하는 제약이 생기고, 프로퍼티에 저장해 계속해서 사용하지 못하고 필요할때 마다 생성해서 사용해야 하는 상황이 자주 있을것 같아 비효율적일 수 있다고 생각이 들었습니다.
    - 현재 `ReciptReciptSender`가 나중에 어떤 문제를 야기할 수 있을지, 더 좋은 방법은 없을지 조언 부탁드립니다!

