### PR TITLE
택배 송장 [STEP 2] honghoker

### DIFF
--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		517BC6D72B9DD3E600D7A9D3 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6D62B9DD3E600D7A9D3 /* UILabel+.swift */; };
 		517BC6DA2B9DD7C200D7A9D3 /* DeliveryCost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6D92B9DD7C200D7A9D3 /* DeliveryCost.swift */; };
+		517BC6DC2B9DDE6900D7A9D3 /* DiscountStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6DB2B9DDE6900D7A9D3 /* DiscountStrategy.swift */; };
+		517BC6DE2B9DDEDD00D7A9D3 /* Discount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6DD2B9DDEDD00D7A9D3 /* Discount.swift */; };
 		519546682B99DD650090BD44 /* ParcelInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546672B99DD650090BD44 /* ParcelInformation.swift */; };
 		5195466A2B99DD700090BD44 /* ReceiverInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546692B99DD700090BD44 /* ReceiverInformation.swift */; };
 		519546752B99DFA90090BD44 /* ParcelInformationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546742B99DFA90090BD44 /* ParcelInformationPersistence.swift */; };
@@ -28,6 +30,8 @@
 /* Begin PBXFileReference section */
 		517BC6D62B9DD3E600D7A9D3 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		517BC6D92B9DD7C200D7A9D3 /* DeliveryCost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryCost.swift; sourceTree = "<group>"; };
+		517BC6DB2B9DDE6900D7A9D3 /* DiscountStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountStrategy.swift; sourceTree = "<group>"; };
+		517BC6DD2B9DDEDD00D7A9D3 /* Discount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Discount.swift; sourceTree = "<group>"; };
 		519546672B99DD650090BD44 /* ParcelInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformation.swift; sourceTree = "<group>"; };
 		519546692B99DD700090BD44 /* ReceiverInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiverInformation.swift; sourceTree = "<group>"; };
 		519546742B99DFA90090BD44 /* ParcelInformationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformationPersistence.swift; sourceTree = "<group>"; };
@@ -73,6 +77,8 @@
 				519546672B99DD650090BD44 /* ParcelInformation.swift */,
 				519546692B99DD700090BD44 /* ReceiverInformation.swift */,
 				517BC6D92B9DD7C200D7A9D3 /* DeliveryCost.swift */,
+				517BC6DB2B9DDE6900D7A9D3 /* DiscountStrategy.swift */,
+				517BC6DD2B9DDEDD00D7A9D3 /* Discount.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -281,6 +287,7 @@
 			files = (
 				517BC6DA2B9DD7C200D7A9D3 /* DeliveryCost.swift in Sources */,
 				C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */,
+				517BC6DE2B9DDEDD00D7A9D3 /* Discount.swift in Sources */,
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,
 				5195467D2B99DFE60090BD44 /* ParcelOrderProcessor.swift in Sources */,
 				517BC6D72B9DD3E600D7A9D3 /* UILabel+.swift in Sources */,
@@ -290,6 +297,7 @@
 				C741F5122B468AA300A4DDC0 /* ParcelOrderView.swift in Sources */,
 				C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */,
 				519546682B99DD650090BD44 /* ParcelInformation.swift in Sources */,
+				517BC6DC2B9DDE6900D7A9D3 /* DiscountStrategy.swift in Sources */,
 				5195466A2B99DD700090BD44 /* ReceiverInformation.swift in Sources */,
 				519546772B99DFBB0090BD44 /* DatabaseParcelInformationPersistence.swift in Sources */,
 				519546752B99DFA90090BD44 /* ParcelInformationPersistence.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		517BC6D72B9DD3E600D7A9D3 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6D62B9DD3E600D7A9D3 /* UILabel+.swift */; };
+		517BC6DA2B9DD7C200D7A9D3 /* DeliveryCost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6D92B9DD7C200D7A9D3 /* DeliveryCost.swift */; };
 		519546682B99DD650090BD44 /* ParcelInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546672B99DD650090BD44 /* ParcelInformation.swift */; };
 		5195466A2B99DD700090BD44 /* ReceiverInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546692B99DD700090BD44 /* ReceiverInformation.swift */; };
 		519546752B99DFA90090BD44 /* ParcelInformationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546742B99DFA90090BD44 /* ParcelInformationPersistence.swift */; };
@@ -26,6 +27,7 @@
 
 /* Begin PBXFileReference section */
 		517BC6D62B9DD3E600D7A9D3 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
+		517BC6D92B9DD7C200D7A9D3 /* DeliveryCost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryCost.swift; sourceTree = "<group>"; };
 		519546672B99DD650090BD44 /* ParcelInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformation.swift; sourceTree = "<group>"; };
 		519546692B99DD700090BD44 /* ReceiverInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiverInformation.swift; sourceTree = "<group>"; };
 		519546742B99DFA90090BD44 /* ParcelInformationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformationPersistence.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 				519546722B99DF960090BD44 /* Repository */,
 				519546672B99DD650090BD44 /* ParcelInformation.swift */,
 				519546692B99DD700090BD44 /* ReceiverInformation.swift */,
+				517BC6D92B9DD7C200D7A9D3 /* DeliveryCost.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -276,6 +279,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				517BC6DA2B9DD7C200D7A9D3 /* DeliveryCost.swift in Sources */,
 				C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */,
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,
 				5195467D2B99DFE60090BD44 /* ParcelOrderProcessor.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		517BC6D72B9DD3E600D7A9D3 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6D62B9DD3E600D7A9D3 /* UILabel+.swift */; };
 		519546682B99DD650090BD44 /* ParcelInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546672B99DD650090BD44 /* ParcelInformation.swift */; };
 		5195466A2B99DD700090BD44 /* ReceiverInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546692B99DD700090BD44 /* ReceiverInformation.swift */; };
 		519546752B99DFA90090BD44 /* ParcelInformationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546742B99DFA90090BD44 /* ParcelInformationPersistence.swift */; };
@@ -24,6 +25,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		517BC6D62B9DD3E600D7A9D3 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		519546672B99DD650090BD44 /* ParcelInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformation.swift; sourceTree = "<group>"; };
 		519546692B99DD700090BD44 /* ReceiverInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiverInformation.swift; sourceTree = "<group>"; };
 		519546742B99DFA90090BD44 /* ParcelInformationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformationPersistence.swift; sourceTree = "<group>"; };
@@ -53,6 +55,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		517BC6D52B9DD3DB00D7A9D3 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				517BC6D62B9DD3E600D7A9D3 /* UILabel+.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		519546662B99DD500090BD44 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -186,6 +196,7 @@
 		C741F4F82B46658300A4DDC0 /* ParcelInvoiceMaker */ = {
 			isa = PBXGroup;
 			children = (
+				517BC6D52B9DD3DB00D7A9D3 /* Extensions */,
 				5195467F2B99F1470090BD44 /* Application */,
 				5195466F2B99DF670090BD44 /* Views */,
 				5195466C2B99DE7A0090BD44 /* ViewControllers */,
@@ -268,6 +279,7 @@
 				C741F4FE2B46658300A4DDC0 /* ParcelOrderViewController.swift in Sources */,
 				C741F5142B468AC300A4DDC0 /* InvoiceView.swift in Sources */,
 				5195467D2B99DFE60090BD44 /* ParcelOrderProcessor.swift in Sources */,
+				517BC6D72B9DD3E600D7A9D3 /* UILabel+.swift in Sources */,
 				C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */,
 				C741F5102B4675AF00A4DDC0 /* InvoiceViewController.swift in Sources */,
 				5195467B2B99DFDC0090BD44 /* ParcelOrderProcessable.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		517BC6DA2B9DD7C200D7A9D3 /* DeliveryCost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6D92B9DD7C200D7A9D3 /* DeliveryCost.swift */; };
 		517BC6DC2B9DDE6900D7A9D3 /* DiscountStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6DB2B9DDE6900D7A9D3 /* DiscountStrategy.swift */; };
 		517BC6DE2B9DDEDD00D7A9D3 /* Discount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6DD2B9DDEDD00D7A9D3 /* Discount.swift */; };
+		517BC6E02B9DE49400D7A9D3 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BC6DF2B9DE49400D7A9D3 /* UIStackView+.swift */; };
 		519546682B99DD650090BD44 /* ParcelInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546672B99DD650090BD44 /* ParcelInformation.swift */; };
 		5195466A2B99DD700090BD44 /* ReceiverInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546692B99DD700090BD44 /* ReceiverInformation.swift */; };
 		519546752B99DFA90090BD44 /* ParcelInformationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519546742B99DFA90090BD44 /* ParcelInformationPersistence.swift */; };
@@ -32,6 +33,7 @@
 		517BC6D92B9DD7C200D7A9D3 /* DeliveryCost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryCost.swift; sourceTree = "<group>"; };
 		517BC6DB2B9DDE6900D7A9D3 /* DiscountStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountStrategy.swift; sourceTree = "<group>"; };
 		517BC6DD2B9DDEDD00D7A9D3 /* Discount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Discount.swift; sourceTree = "<group>"; };
+		517BC6DF2B9DE49400D7A9D3 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		519546672B99DD650090BD44 /* ParcelInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformation.swift; sourceTree = "<group>"; };
 		519546692B99DD700090BD44 /* ReceiverInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiverInformation.swift; sourceTree = "<group>"; };
 		519546742B99DFA90090BD44 /* ParcelInformationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParcelInformationPersistence.swift; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 			isa = PBXGroup;
 			children = (
 				517BC6D62B9DD3E600D7A9D3 /* UILabel+.swift */,
+				517BC6DF2B9DE49400D7A9D3 /* UIStackView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -293,6 +296,7 @@
 				517BC6D72B9DD3E600D7A9D3 /* UILabel+.swift in Sources */,
 				C741F4FA2B46658300A4DDC0 /* AppDelegate.swift in Sources */,
 				C741F5102B4675AF00A4DDC0 /* InvoiceViewController.swift in Sources */,
+				517BC6E02B9DE49400D7A9D3 /* UIStackView+.swift in Sources */,
 				5195467B2B99DFDC0090BD44 /* ParcelOrderProcessable.swift in Sources */,
 				C741F5122B468AA300A4DDC0 /* ParcelOrderView.swift in Sources */,
 				C741F4FC2B46658300A4DDC0 /* SceneDelegate.swift in Sources */,

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Application/AppDelegate.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Application/AppDelegate.swift
@@ -9,22 +9,20 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   
-  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    // Override point for customization after application launch.
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
     return true
   }
   
   // MARK: UISceneSession Lifecycle
   
-  func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-    // Called when a new scene session is being created.
-    // Use this method to select a configuration to create the new scene with.
-    return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-  }
-  
-  func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-    // Called when the user discards a scene session.
-    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    return .init(name: "Default Configuration", sessionRole: connectingSceneSession.role)
   }
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Extensions/UILabel+.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Extensions/UILabel+.swift
@@ -1,0 +1,29 @@
+//
+//  UILabel+.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 홍은표 on 3/10/24.
+//
+
+import UIKit
+
+extension UILabel {
+  convenience init(text: String, color textColor: UIColor, font: UIFont) {
+    self.init()
+    self.text = text
+    self.textColor = textColor
+    self.font = font
+  }
+  
+  convenience init(
+    text: String, color
+    textColor: UIColor, 
+    huggingPriority priority: UILayoutPriority,
+    for axis: NSLayoutConstraint.Axis
+  ) {
+    self.init()
+    self.text = text
+    self.textColor = textColor
+    self.setContentHuggingPriority(priority, for: axis)
+  }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Extensions/UIStackView+.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Extensions/UIStackView+.swift
@@ -1,0 +1,22 @@
+//
+//  UIStackView+.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 홍은표 on 3/10/24.
+//
+
+import UIKit
+
+extension UIStackView {
+  convenience init(
+    arrangedSubviews views: [UIView],
+    distribution: UIStackView.Distribution = .fill,
+    spacing: CGFloat,
+    axis: NSLayoutConstraint.Axis
+  ) {
+    self.init(arrangedSubviews: views)
+    self.distribution = distribution
+    self.spacing = spacing
+    self.axis = axis
+  }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/DeliveryCost.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/DeliveryCost.swift
@@ -1,0 +1,33 @@
+//
+//  DeliveryCost.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 홍은표 on 3/10/24.
+//
+
+import Foundation
+
+enum Discount: Int {
+  case none = 0, vip, coupon
+}
+
+struct DeliveryCost {
+  private let cost: Int
+  private let discount: Discount
+  
+  init(cost: Int, discount: Discount) {
+    self.cost = cost
+    self.discount = discount
+  }
+  
+  func getDiscountedCost() -> Int {
+    switch discount {
+    case .none:
+      return cost
+    case .vip:
+      return cost / 5 * 4
+    case .coupon:
+      return cost / 2
+    }
+  }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/DeliveryCost.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/DeliveryCost.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-enum Discount: Int {
-  case none = 0, vip, coupon
-}
-
 struct DeliveryCost {
   private let cost: Int
   private let discount: Discount
@@ -21,13 +17,6 @@ struct DeliveryCost {
   }
   
   func getDiscountedCost() -> Int {
-    switch discount {
-    case .none:
-      return cost
-    case .vip:
-      return cost / 5 * 4
-    case .coupon:
-      return cost / 2
-    }
+    discount.strategy.applyDiscount(deliveryCost: cost)
   }
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/Discount.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/Discount.swift
@@ -1,0 +1,23 @@
+//
+//  Discount.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 홍은표 on 3/10/24.
+//
+
+import Foundation
+
+enum Discount: Int {
+  case none = 0, vip, coupon
+  
+  var strategy: DiscountStrategy {
+    switch self {
+    case .none:
+      NoDiscount()
+    case .vip:
+      VIPDiscount()
+    case .coupon:
+      CouponDiscount()
+    }
+  }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/Discount.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/Discount.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum Discount: Int {
+enum Discount: Int, CaseIterable {
   case none = 0, vip, coupon
   
   var strategy: DiscountStrategy {
@@ -18,6 +18,17 @@ enum Discount: Int {
       VIPDiscount()
     case .coupon:
       CouponDiscount()
+    }
+  }
+  
+  var title: String {
+    switch self {
+    case .none:
+      "없음"
+    case .vip:
+      "VIP"
+    case .coupon:
+      "쿠폰"
     }
   }
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/DiscountStrategy.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/DiscountStrategy.swift
@@ -1,0 +1,30 @@
+//
+//  DiscountStrategy.swift
+//  ParcelInvoiceMaker
+//
+//  Created by 홍은표 on 3/10/24.
+//
+
+import Foundation
+
+protocol DiscountStrategy {
+  func applyDiscount(deliveryCost: Int) -> Int
+}
+
+struct NoDiscount: DiscountStrategy {
+  func applyDiscount(deliveryCost: Int) -> Int {
+    return deliveryCost
+  }
+}
+
+struct VIPDiscount: DiscountStrategy {
+  func applyDiscount(deliveryCost: Int) -> Int {
+    return deliveryCost / 5 * 4
+  }
+}
+
+struct CouponDiscount: DiscountStrategy {
+  func applyDiscount(deliveryCost: Int) -> Int {
+    return deliveryCost / 2
+  }
+}

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/ParcelInformation.swift
@@ -8,26 +8,14 @@
 import Foundation
 
 struct ParcelInformation {
-  private let receiverInformation: ReceiverInformation
+  let receiver: ReceiverInformation
   private let deliveryCost: Int
   private let discount: Discount
   
-  init(receiverInformation: ReceiverInformation, deliveryCost: Int, discount: Discount) {
-    self.receiverInformation = receiverInformation
+  init(receiver: ReceiverInformation, deliveryCost: Int, discount: Discount) {
+    self.receiver = receiver
     self.deliveryCost = deliveryCost
     self.discount = discount
-  }
-  
-  func getReceiverAddress() -> String {
-    return receiverInformation.getAddress()
-  }
-  
-  func getReceiverName() -> String {
-    return receiverInformation.getName()
-  }
-  
-  func getReceiverMobile() -> String {
-    return receiverInformation.getMobile()
   }
   
   func getDiscountedCost() -> Int {

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/ParcelInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/ParcelInformation.swift
@@ -9,27 +9,10 @@ import Foundation
 
 struct ParcelInformation {
   let receiver: ReceiverInformation
-  private let deliveryCost: Int
-  private let discount: Discount
+  let deliveryCost: DeliveryCost
   
-  init(receiver: ReceiverInformation, deliveryCost: Int, discount: Discount) {
+  init(receiver: ReceiverInformation, deliveryCost: DeliveryCost) {
     self.receiver = receiver
     self.deliveryCost = deliveryCost
-    self.discount = discount
   }
-  
-  func getDiscountedCost() -> Int {
-    switch discount {
-    case .none:
-      return deliveryCost
-    case .vip:
-      return deliveryCost / 5 * 4
-    case .coupon:
-      return deliveryCost / 2
-    }
-  }
-}
-
-enum Discount: Int {
-  case none = 0, vip, coupon
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/ReceiverInformation.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Models/ReceiverInformation.swift
@@ -8,25 +8,13 @@
 import Foundation
 
 struct ReceiverInformation {
-  private let address: String
-  private let name: String
-  private let mobile: String
+  let address: String
+  let name: String
+  let mobile: String
   
   init(address: String, name: String, mobile: String) {
     self.address = address
     self.name = name
     self.mobile = mobile
-  }
-  
-  func getAddress() -> String {
-    return address
-  }
-  
-  func getName() -> String {
-    return name
-  }
-  
-  func getMobile() -> String {
-    return mobile
   }
 }

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/Invoice/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/Invoice/InvoiceView.swift
@@ -24,17 +24,17 @@ final class InvoiceView: UIView {
     let nameLabel: UILabel = .init()
     nameLabel.textColor = .black
     nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-    nameLabel.text = "이름 : \(parcelInformation.getReceiverName())"
+    nameLabel.text = "이름 : \(parcelInformation.receiver.name)"
     
     let mobileLabel: UILabel = .init()
     mobileLabel.textColor = .black
     mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-    mobileLabel.text = "전화 : \(parcelInformation.getReceiverMobile())"
+    mobileLabel.text = "전화 : \(parcelInformation.receiver.mobile)"
     
     let addressLabel: UILabel = .init()
     addressLabel.textColor = .black
     addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-    addressLabel.text = "주소 : \(parcelInformation.getReceiverAddress())"
+    addressLabel.text = "주소 : \(parcelInformation.receiver.address)"
     
     let costLabel: UILabel = .init()
     costLabel.textColor = .black

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/Invoice/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/Invoice/InvoiceView.swift
@@ -46,10 +46,10 @@ final class InvoiceView: UIView {
     )
     
     let mainStackView: UIStackView = .init(
-      arrangedSubviews: [nameLabel, mobileLabel, addressLabel, costLabel]
+      arrangedSubviews: [nameLabel, mobileLabel, addressLabel, costLabel],
+      spacing: 16,
+      axis: .vertical
     )
-    mainStackView.axis = .vertical
-    mainStackView.spacing = 16
     mainStackView.translatesAutoresizingMaskIntoConstraints = false
     addSubview(mainStackView)
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/Invoice/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/Invoice/InvoiceView.swift
@@ -40,7 +40,7 @@ final class InvoiceView: UIView {
     )
     
     let costLabel: UILabel = .init(
-      text: "요금 : \(parcelInformation.getDiscountedCost())",
+      text: "요금 : \(parcelInformation.deliveryCost.getDiscountedCost())",
       color: .black,
       font: .preferredFont(forTextStyle: .largeTitle)
     )

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/Invoice/InvoiceView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/Invoice/InvoiceView.swift
@@ -21,25 +21,29 @@ final class InvoiceView: UIView {
   }
   
   private func layoutView() {
-    let nameLabel: UILabel = .init()
-    nameLabel.textColor = .black
-    nameLabel.font = .preferredFont(forTextStyle: .largeTitle)
-    nameLabel.text = "이름 : \(parcelInformation.receiver.name)"
+    let nameLabel: UILabel = .init(
+      text: "이름 : \(parcelInformation.receiver.name)",
+      color: .black,
+      font: .preferredFont(forTextStyle: .largeTitle)
+    )
     
-    let mobileLabel: UILabel = .init()
-    mobileLabel.textColor = .black
-    mobileLabel.font = .preferredFont(forTextStyle: .largeTitle)
-    mobileLabel.text = "전화 : \(parcelInformation.receiver.mobile)"
+    let mobileLabel: UILabel = .init(
+      text: "전화 : \(parcelInformation.receiver.mobile)",
+      color: .black,
+      font: .preferredFont(forTextStyle: .largeTitle)
+    )
     
-    let addressLabel: UILabel = .init()
-    addressLabel.textColor = .black
-    addressLabel.font = .preferredFont(forTextStyle: .largeTitle)
-    addressLabel.text = "주소 : \(parcelInformation.receiver.address)"
+    let addressLabel: UILabel = .init(
+      text: "주소 : \(parcelInformation.receiver.address)",
+      color: .black,
+      font: .preferredFont(forTextStyle: .largeTitle)
+    )
     
-    let costLabel: UILabel = .init()
-    costLabel.textColor = .black
-    costLabel.font = .preferredFont(forTextStyle: .largeTitle)
-    costLabel.text = "요금 : \(parcelInformation.getDiscountedCost())"
+    let costLabel: UILabel = .init(
+      text: "요금 : \(parcelInformation.getDiscountedCost())",
+      color: .black,
+      font: .preferredFont(forTextStyle: .largeTitle)
+    )
     
     let mainStackView: UIStackView = .init(
       arrangedSubviews: [nameLabel, mobileLabel, addressLabel, costLabel]

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
@@ -91,35 +91,40 @@ final class ParcelOrderView: UIView {
     let logoImageView: UIImageView = .init(image: .init(named: "post_office_logo"))
     logoImageView.contentMode = .scaleAspectFit
     
-    let nameLabel: UILabel = .init()
-    nameLabel.textColor = .black
-    nameLabel.text = "이름"
-    nameLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    let nameLabel: UILabel = .init(
+      text: "이름",
+      color: .black,
+      huggingPriority: .defaultHigh,
+      for: .horizontal
+    )
     
-    let mobileLabel: UILabel = .init()
-    mobileLabel.textColor = .black
-    mobileLabel.text = "전화"
-    mobileLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    let mobileLabel: UILabel = .init(
+      text: "전화",
+      color: .black,
+      huggingPriority: .defaultHigh,
+      for: .horizontal
+    )
     
-    let addressLabel: UILabel = .init()
-    addressLabel.textColor = .black
-    addressLabel.text = "주소"
-    addressLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    let addressLabel: UILabel = .init(
+      text: "주소",
+      color: .black,
+      huggingPriority: .defaultHigh,
+      for: .horizontal
+    )
     
-    let costLabel: UILabel = .init()
-    costLabel.textColor = .black
-    costLabel.text = "요금"
-    costLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    let costLabel: UILabel = .init(
+      text: "요금",
+      color: .black,
+      huggingPriority: .defaultHigh,
+      for: .horizontal
+    )
     
-    let discountLabel: UILabel = .init()
-    discountLabel.textColor = .black
-    discountLabel.text = "할인"
-    discountLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-    
-    let notificationLabel: UILabel = .init()
-    notificationLabel.textColor = .black
-    notificationLabel.text = "알림"
-    notificationLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    let discountLabel: UILabel = .init(
+      text: "할인",
+      color: .black,
+      huggingPriority: .defaultHigh,
+      for: .horizontal
+    )    
     
     let nameStackView: UIStackView = .init(arrangedSubviews: [nameLabel, receiverNameField])
     nameStackView.distribution = .fill

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
@@ -126,26 +126,35 @@ final class ParcelOrderView: UIView {
       for: .horizontal
     )    
     
-    let nameStackView: UIStackView = .init(arrangedSubviews: [nameLabel, receiverNameField])
-    nameStackView.distribution = .fill
-    nameStackView.spacing = 8
-    nameStackView.axis = .horizontal
+    let nameStackView: UIStackView = .init(
+      arrangedSubviews: [nameLabel, receiverNameField],
+      spacing: 8,
+      axis: .horizontal
+    )
     
-    let mobileStackView: UIStackView = .init(arrangedSubviews: [mobileLabel, receiverMobileField])
-    mobileStackView.spacing = 8
-    mobileStackView.axis = .horizontal
+    let mobileStackView: UIStackView = .init(
+      arrangedSubviews: [mobileLabel, receiverMobileField],
+      spacing: 8,
+      axis: .horizontal
+    )
     
-    let addressStackView: UIStackView = .init(arrangedSubviews: [addressLabel, addressField])
-    addressStackView.spacing = 8
-    addressStackView.axis = .horizontal
+    let addressStackView: UIStackView = .init(
+      arrangedSubviews: [addressLabel, addressField],
+      spacing: 8,
+      axis: .horizontal
+    )
     
-    let costStackView: UIStackView = .init(arrangedSubviews: [costLabel, costField])
-    costStackView.spacing = 8
-    costStackView.axis = .horizontal
+    let costStackView: UIStackView = .init(
+      arrangedSubviews: [costLabel, costField],
+      spacing: 8,
+      axis: .horizontal
+    )
     
-    let discountStackView: UIStackView = .init(arrangedSubviews: [discountLabel, discountSegmented])
-    discountStackView.spacing = 8
-    discountStackView.axis = .horizontal
+    let discountStackView: UIStackView = .init(
+      arrangedSubviews: [discountLabel, discountSegmented],
+      spacing: 8,
+      axis: .horizontal
+    )
     
     let makeOrderButton: UIButton = .init(type: .system)
     makeOrderButton.backgroundColor = .white
@@ -161,11 +170,11 @@ final class ParcelOrderView: UIView {
         costStackView, 
         discountStackView,
         makeOrderButton
-      ]
+      ],
+      distribution: .fillEqually,
+      spacing: 8,
+      axis: .vertical
     )
-    mainStackView.axis = .vertical
-    mainStackView.distribution = .fillEqually
-    mainStackView.spacing = 8
     mainStackView.translatesAutoresizingMaskIntoConstraints = false
     addSubview(mainStackView)
     

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
@@ -77,10 +77,10 @@ final class ParcelOrderView: UIView {
     }
     
     let receiver: ReceiverInformation = .init(address: address, name: name, mobile: mobile)
+    let deliveryCost: DeliveryCost = .init(cost: cost, discount: discount)
     let parcelInformation: ParcelInformation = .init(
         receiver: receiver,
-        deliveryCost: cost,
-        discount: discount
+        deliveryCost: deliveryCost
     )
     
     delegate?.parcelOrderMade(parcelInformation)

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
@@ -76,9 +76,9 @@ final class ParcelOrderView: UIView {
       return
     }
     
-    let receiverInformation: ReceiverInformation = .init(address: address, name: name, mobile: mobile)
+    let receiver: ReceiverInformation = .init(address: address, name: name, mobile: mobile)
     let parcelInformation: ParcelInformation = .init(
-        receiverInformation: receiverInformation,
+        receiver: receiver,
         deliveryCost: cost,
         discount: discount
     )

--- a/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
+++ b/ParcelInvoiceMaker/ParcelInvoiceMaker/Views/ParcelOrder/ParcelOrderView.swift
@@ -42,9 +42,9 @@ final class ParcelOrderView: UIView {
   
   private let discountSegmented: UISegmentedControl = {
     let control: UISegmentedControl = .init()
-    control.insertSegment(withTitle: "없음", at: 0, animated: false)
-    control.insertSegment(withTitle: "VIP", at: 1, animated: false)
-    control.insertSegment(withTitle: "쿠폰", at: 2, animated: false)
+    for discount in Discount.allCases {
+      control.insertSegment(withTitle: discount.title, at: discount.rawValue, animated: false)
+    }
     control.selectedSegmentIndex = 0
     return control
   }()


### PR DESCRIPTION
@ryan-son 
안녕하세요! STEP 2 에서 다시 뵙습니다!
STEP 1 에서 남겨주신 코멘트들 보고 평소에 하던 고민들이 어느정도 해소되었습니다! 감사해요!
제 생각이 조금 더 정리되면 궁금한 점 따로 DM 드리도록 하겠습니다 :)

이번 PR은 STEP 2의 내용과 STEP 1에서 남겨주신 코멘트들을 참고해서 수정한 내용이 포함되어 있습니다!

### STEP 2 : OCP의 실현

## SOLID OCP / 객체 미용 체조 2원칙 적용
- OCP를 적용하는 것과 함께 ParcelInformation가 가지고 있던 deliveryCost, discount 프로퍼티를 묶기 위해 DeliveryCost model을 생성해주고 해당 Model이 가격과 관련된 정보들을 관리할 수 있도록 변경하였습니다.

## 기타 수정사항별 이유
- ParcelOrderView에서 SegmentedControl 를 생성해줄 때, 매직 넘버가 들어가고 있어 추후 Discount의 case가 추가될 때 View도 함께 변경되어야하는 번거로움을 제거하고자 CaseIterable을 채택하여 SegmentedControl의 요소를 동적으로 생성할 수 있도록 하였습니다.

---

## 조언 부탁드려요!

### 반복되는 구성의 인스턴스 재사용성 증가
STEP 1 에서 조언해주신 내용에 따라 UILabel, UIStackView 인스턴스를 생성할 때 반복되는 코드를 편의 이니셜라이즈를 적용하여 재사용성 증가를 하고자하였습니다.
별도의 해당 인스턴스를 상속, 팩토리 메서드를 사용하지 않고 편의 이니셜라이즈를 사용한 이유는 프로젝트의 크기가 커질수록 파일들이 많아지고 과거에 만들어놨지만 가끔 까먹고 만들다가 이런 기능들을 만들어놨구나 하고 경우가 있는데요. 
(사실 이런 부분 때문에 모듈화나 폴더링에 많은 고민을 하는거 같습니다.)

이번 프로젝트는 별도의 디자인 시스템이 없고, 누구나 UILabel, UIStackView를 생성할 때 자동 완성을 통해 이런 이니셜라이즈가 있구나! 라고 확인할 수 있다는 장점이 있으니 편의 인스턴스를 만들어놓고 사용하는게 낫지않을까하여 편의 이니셜라이즈를 통해 인스턴스를 생성하도록 하였습니다.

편의 이니셜라이즈의 단점이라고 생각되는건 주석을 별도로 달아주지 않는 이상 생성할 때 넘겨주는 아규먼트의 이름들을 보고 어떤 뷰를 생성하구나를 판단해야 하는데요. 
(주석을 별도로 달아주지 않고 생성할 때 넘겨주는 아규먼트 이름을 누구나 알아보기 쉽게 작성해준다면 크게 단점이라고 생각하진 않긴합니다.)

이런 단점때문에 어떤 방법을 사용해서 재사용성을 증가시켜줘야할 지에 대한 고민을 많이 하게되었습니다.

ryan이라면 이번 프로젝트에서 UILabel, UIStackView 인스턴스를 생성할 때 재사용성을 높이기 위해 어떤 방법을 선택하셨을지 궁금합니다!

---

변경 사항 중 조금이라도 애매한 게 있다면 의견 주시면 감사하겠습니다!
주말인데 확인해주셔서 감사합니다 :)